### PR TITLE
Enhance search for GCMD vocabulary values

### DIFF
--- a/metanorm/normalizers/sentinel_safe.py
+++ b/metanorm/normalizers/sentinel_safe.py
@@ -60,12 +60,16 @@ class SentinelSAFEMetadataNormalizer(BaseMetadataNormalizer):
     def get_instrument(self, raw_attributes):
         """Get the instrument from the attributes'"""
         if set(['Instrument']).issubset(raw_attributes.keys()):
-            # This is ugly but necessary as long as pythesint can't find SAR from 'SAR-C'
-            if raw_attributes['Instrument'].startswith('SAR-'):
-                instrument = 'SAR'
+            # This is ugly but pythesint can't find C-SAR from 'SAR-C'
+            if 'SAR-C' in raw_attributes['Instrument']:
+                instrument = 'C-SAR'
             else:
                 instrument = raw_attributes['Instrument']
-            return utils.get_gcmd_instrument(instrument)
+
+            additional_keywords = []
+            if set(['Satellite name']).issubset(raw_attributes.keys()):
+                additional_keywords.append(raw_attributes['Satellite name'])
+            return utils.get_gcmd_instrument(instrument, additional_keywords)
         else:
             return None
 

--- a/metanorm/utils.py
+++ b/metanorm/utils.py
@@ -10,18 +10,17 @@ import pythesint as pti
 UNKNOWN = 'Unknown'
 
 
-def get_gcmd_provider(potential_provider_attributes):
+def get_gcmd_provider(potential_provider_attributes, additional_keywords=None):
     """
-    Gets a GCMD provider from a name and/or URL, otherwise generate a GCMD provider-like data
-    structure
+    Get a GCMD provider from a name and/or URL, otherwise return None
     """
     provider = None
     for attribute in potential_provider_attributes:
-        try:
-            provider = pti.get_gcmd_provider(attribute)
-        except IndexError:
-            pass
+        provider = gcmd_search('provider', attribute, additional_keywords)
+        if provider:
+            break
     return provider
+
 
 def get_gcmd_like_provider(name=None, url=None):
     """Generate a GCMD provider-like data structure using a name and a URL"""
@@ -29,11 +28,8 @@ def get_gcmd_like_provider(name=None, url=None):
     if not name:
         short_name = long_name = UNKNOWN
     else:
-        if len(name) <= 50:
-            short_name = long_name = name
-        else:
-            short_name = name[:50]
-            long_name = name if len(name) < 250 else name[:250]
+        short_name = name[:50]
+        long_name = name[:250]
     provider = OrderedDict([
         ('Bucket_Level0', UNKNOWN),
         ('Bucket_Level1', UNKNOWN),
@@ -46,41 +42,95 @@ def get_gcmd_like_provider(name=None, url=None):
 
     return provider
 
-def get_gcmd_platform(platform_name):
+
+def get_gcmd_platform(platform_name, additional_keywords=None):
     """
     Gets a GCMD platform from a platform name, otherwise generate a GCMD platform-like data
     structure
     """
-    try:
-        gcmd_platform = pti.get_gcmd_platform(platform_name)
-    except IndexError:  # TODO: find a better way to manage the fallback value
+    gcmd_platform = gcmd_search('platform', platform_name, additional_keywords)
+
+    if not gcmd_platform:  # TODO: find a better way to manage the fallback value
         gcmd_platform = OrderedDict([
             ('Category', UNKNOWN),
             ('Series_Entity', UNKNOWN),
-            ('Short_Name', platform_name if len(platform_name) < 100 else platform_name[:100]),
-            ('Long_Name', platform_name if len(platform_name) < 250 else platform_name[:250])
+            ('Short_Name', platform_name[:100]),
+            ('Long_Name', platform_name[:250])
         ])
 
     return gcmd_platform
 
-def get_gcmd_instrument(instrument_name):
+
+def get_gcmd_instrument(instrument_name, additional_keywords=None):
     """
-    Gets a GCMD platform from a instrument name, otherwise generate a GCMD instrument-like data
-    structure
+    Gets a GCMD instrument from an instrument name, otherwise generate a GCMD instrument-like data
+    structure.
     """
-    try:
-        gcmd_instrument = pti.get_gcmd_instrument(instrument_name)
-    except IndexError:  # TODO: find a better way to manage the fallback value
+    gcmd_instrument = gcmd_search('instrument', instrument_name, additional_keywords)
+
+    if not gcmd_instrument:
         gcmd_instrument = OrderedDict([
             ('Category', UNKNOWN),
             ('Class', UNKNOWN),
             ('Type', UNKNOWN),
             ('Subtype', UNKNOWN),
-            ('Short_Name', instrument_name if len(instrument_name) < 60 else instrument_name[:60]),
-            ('Long_Name', instrument_name if len(instrument_name) < 200 else instrument_name[:200])
+            ('Short_Name', instrument_name[:60]),
+            ('Long_Name', instrument_name[:200])
         ])
 
     return gcmd_instrument
+
+
+def gcmd_search(vocabulary_name, keyword, additional_keywords=None):
+    """
+    Search for GCMD objects using the provided vocabulary name and keywords.
+    Returns None if nothing was found.
+    """
+    pti_search_method = getattr(pti, f"search_gcmd_{vocabulary_name}_list")
+    pti_get_method = getattr(pti, f"get_gcmd_{vocabulary_name}")
+
+    gcmd_object = None
+    # Try to search for the object name
+    matching_objects = pti_search_method(keyword)
+    matching_objects_length = len(matching_objects)
+
+    if matching_objects_length == 1:
+        gcmd_object = matching_objects[0]
+    # If more than one is found, look for the additional keywords
+    # in the search results to narrow it down
+    elif matching_objects_length > 1 and additional_keywords:
+        restricted_search = restrict_gcmd_search(matching_objects, additional_keywords)
+        restricted_search_length = len(restricted_search)
+        if restricted_search_length == 1:
+            gcmd_object = restricted_search[0]
+
+    if not gcmd_object:
+        # If the additional keywords did not manage to narrow down the search enough, or if no
+        # additional keyword was provided, try the strict `get_` method from pythesint
+        try:
+            gcmd_object = pti_get_method(keyword)
+        except IndexError:
+            pass
+
+    return gcmd_object
+
+
+def restrict_gcmd_search(gcmd_objects, keywords):
+    """Restricts a list of GCMD objects using a list of keywords to search"""
+    restricted_search = gcmd_objects.copy()
+    restricted_search_length = len(restricted_search)
+
+    for keyword in keywords:
+        keyword_search = [
+            gcmd_object for gcmd_object in restricted_search
+            if keyword.lower() in str(gcmd_object).lower()
+        ]
+        keyword_search_length = len(keyword_search)
+        if keyword_search_length > 0 and keyword_search_length < restricted_search_length:
+            restricted_search = keyword_search
+            restricted_search_length = keyword_search_length
+
+    return restricted_search
 
 
 def wkt_polygon_from_wgs84_limits(north, south, east, west):
@@ -89,6 +139,7 @@ def wkt_polygon_from_wgs84_limits(north, south, east, west):
     latitude, southernmost latitude, easternmost longitude and westernmost longitude
     """
     return f"POLYGON(({west} {south},{east} {south},{east} {north},{west} {north},{west} {south}))"
+
 
 def geometry_from_wkt_string(wkt_string, srid=4326):
     """

--- a/tests/normalizers/test_acdd.py
+++ b/tests/normalizers/test_acdd.py
@@ -75,29 +75,27 @@ class ACDDMetadataNormalizerTestCase(unittest.TestCase):
 
     def test_gcmd_platform(self):
         """gcmd_platform from ACDDMetadataNormalizer"""
-        attributes = {'platform': 'SENTINEL-1'}
-
+        attributes = {'platform': 'SENTINEL-1A'}
         self.assertEqual(
             self.normalizer.get_platform(attributes),
             OrderedDict([
                 ('Category', 'Earth Observation Satellites'),
                 ('Series_Entity', 'SENTINEL-1'),
-                ('Short_Name', ''),
-                ('Long_Name', '')
+                ('Short_Name', 'SENTINEL-1A'),
+                ('Long_Name', 'SENTINEL-1A')
             ])
         )
 
     def test_non_gcmd_platform(self):
         """Non-GCMD platform from ACDDMetadataNormalizer"""
-        attributes = {'platform': 'TEST'}
-
+        attributes = {'platform': 'NONGCMD'}
         self.assertEqual(
             self.normalizer.get_platform(attributes),
             OrderedDict([
                 ('Category', 'Unknown'),
                 ('Series_Entity', 'Unknown'),
-                ('Short_Name', 'TEST'),
-                ('Long_Name', 'TEST')
+                ('Short_Name', 'NONGCMD'),
+                ('Long_Name', 'NONGCMD')
             ])
         )
 
@@ -256,7 +254,7 @@ class ACDDMetadataNormalizerTestCase(unittest.TestCase):
     def test_non_gcmd_provider(self):
         """Non-GCMD provider from ACDDMetadataNormalizer"""
         attributes = {
-            'publisher_name': 'TEST',
+            'publisher_name': 'NONGCMD',
             'publisher_url': 'http://random.url'
         }
 
@@ -267,8 +265,8 @@ class ACDDMetadataNormalizerTestCase(unittest.TestCase):
                 ('Bucket_Level1', 'Unknown'),
                 ('Bucket_Level2', 'Unknown'),
                 ('Bucket_Level3', 'Unknown'),
-                ('Short_Name', 'TEST'),
-                ('Long_Name', 'TEST'),
+                ('Short_Name', 'NONGCMD'),
+                ('Long_Name', 'NONGCMD'),
                 ('Data_Center_URL', 'http://random.url')
             ])
         )

--- a/tests/normalizers/test_sentinel_safe.py
+++ b/tests/normalizers/test_sentinel_safe.py
@@ -132,18 +132,66 @@ class SentinelSAFEMetadataNormalizerTestCase(unittest.TestCase):
         """Parameter method must return None if the attribute is missing"""
         self.assertEqual(self.normalizer.get_platform({}), None)
 
-    def test_gcmd_instrument(self):
-        """GCMD instrument from SentinelSAFEMetadataNormalizer"""
-        attributes = {'Instrument': 'SAR-C SAR'}
+    def test_gcmd_instrument_from_get(self):
+        """
+        GCMD instrument from SentinelSAFEMetadataNormalizer which is found using
+        `pythesint.get_gcmd_instrument()`
+        """
+        attributes = {'Instrument': 'MODIS'}
+        self.assertEqual(
+            self.normalizer.get_instrument(attributes),
+            OrderedDict([('Category', 'Earth Remote Sensing Instruments'),
+                         ('Class', 'Passive Remote Sensing'),
+                         ('Type', 'Spectrometers/Radiometers'),
+                         ('Subtype', 'Imaging Spectrometers/Radiometers'),
+                         ('Short_Name', 'MODIS'),
+                         ('Long_Name', 'Moderate-Resolution Imaging Spectroradiometer')])
+        )
 
+    def test_gcmd_instrument_from_search(self):
+        """
+        GCMD instrument from SentinelSAFEMetadataNormalizer which is found using
+        `pythesint.search_gcmd_instrument_list()`
+        """
+        attributes = {'Instrument': 'SRAL'}
+        self.assertEqual(
+            self.normalizer.get_instrument(attributes),
+            OrderedDict([('Category', 'Earth Remote Sensing Instruments'),
+                         ('Class', 'Active Remote Sensing'),
+                         ('Type', 'Altimeters'),
+                         ('Subtype', 'Radar Altimeters'),
+                         ('Short_Name', 'Sentinel-3 SRAL'),
+                         ('Long_Name', 'Sentinel-3 SAR Radar Altimeter')])
+        )
+
+    def test_gcmd_instrument_from_restricted_search(self):
+        """
+        GCMD instrument from SentinelSAFEMetadataNormalizer which is found using
+        `pythesint.search_gcmd_instrument_list()` and restricting the search with an
+        additional keyword
+        """
+        attributes = {'Satellite name': 'SENTINEL-2', 'Instrument': 'MSI'}
+        self.assertEqual(
+            self.normalizer.get_instrument(attributes),
+            OrderedDict([('Category', 'Earth Remote Sensing Instruments'),
+                         ('Class', 'Passive Remote Sensing'),
+                         ('Type', 'Spectrometers/Radiometers'),
+                         ('Subtype', 'Imaging Spectrometers/Radiometers'),
+                         ('Short_Name', 'Sentinel-2 MSI'),
+                         ('Long_Name', 'Sentinel-2 Multispectral Imager')])
+        )
+
+    def test_c_sar_instrument(self):
+        """Special case for C-SAR GCMD instrument from SentinelSAFEMetadataNormalizer"""
+        attributes = {'Satellite name': 'SENTINEL-1', 'Instrument': 'SAR-C SAR'}
         self.assertEqual(
             self.normalizer.get_instrument(attributes),
             OrderedDict([('Category', 'Earth Remote Sensing Instruments'),
                          ('Class', 'Active Remote Sensing'),
                          ('Type', 'Imaging Radars'),
                          ('Subtype', ''),
-                         ('Short_Name', 'SAR'),
-                         ('Long_Name', 'Synthetic Aperture Radar')])
+                         ('Short_Name', 'SENTINEL-1 C-SAR'),
+                         ('Long_Name', '')])
         )
 
     def test_non_gcmd_instrument(self):


### PR DESCRIPTION
Closes #4 
By using pythesint `search_gcmd_*_list()` methods, it is easier to find the correct GCMD vocabularies values from the metadata.