### PR TITLE
Issue29 new hardcoded values

### DIFF
--- a/metanorm/normalizers/url.py
+++ b/metanorm/normalizers/url.py
@@ -23,26 +23,26 @@ class URLMetadataNormalizer(BaseMetadataNormalizer):
         "ftp://ftp.remss.com/gmi": 'GPM',
         "ftp://anon-ftp.ceda.ac.uk/neodc/esacci/sst/": 'Earth Observation Satellites',
         "ftp://ftp.gportal.jaxa.jp/standard/GCOM-W": 'GCOM-W1',
-        "ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046":'GCOM-W1',
-        "ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003":'GCOM-W1',
-        "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024":'GCOM-W1'}
+        "ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046":'X',
+        "ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003":'X',
+        "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024":'X'}
 
     urls_instruments = {
         'ftp://ftp.remss.com/gmi': 'GMI',
         'ftp://ftp.gportal.jaxa.jp/standard/GCOM-W/GCOM-W.AMSR2': 'AMSR2',
         'ftp://anon-ftp.ceda.ac.uk/neodc/esacci/sst/':
         'Imaging Spectrometers/Radiometers',
-        "ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046":'GMI',
-        "ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003":'GMI',
-        "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024":'GMI'}
+        "ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046":'X',
+        "ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003":'X',
+        "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024":'X'}
 
     urls_provider = {
         'ftp://anon-ftp.ceda.ac.uk/neodc/esacci/sst/data/CDR_v2/Climatology/L4/v2.1': 'ESA/CCI',
         "ftp://ftp.remss.com/gmi/": 'NASA/GSFC/SED/ESD/LA/GPM',
         "ftp://ftp.gportal.jaxa.jp/standard": 'JP/JAXA/EOC',
-        "ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046":'ESA/CCI',
-        "ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003":'ESA/CCI',
-        "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024":'ESA/CCI'}
+        "ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046":'X',
+        "ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003":'X',
+        "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024":'X'}
 
     urls_geometry = {'ftp://anon-ftp.ceda.ac.uk/neodc/esacci/sst/':
                      ('POLYGON((-180 -90, -180 90, 180 90, 180 -90, -180 -90))'),
@@ -148,6 +148,7 @@ class URLMetadataNormalizer(BaseMetadataNormalizer):
             # for ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046/dataset-duacs-nrt-global-merged-allsat-phy-l4
             "nrt_global_allsat_phy_l4_%Y%m%d",# e.x.: 'nrt_global_allsat_phy_l4_20200206'
             "mercatorpsy4v3r1_%Y%m%d",
+            # for remss
             "f35_%Y%m%dv8.2_d3d.gz",
             "f35_%Y%m%dv8.2.gz",
             "f35_%Y%mv8.2.gz",

--- a/metanorm/normalizers/url.py
+++ b/metanorm/normalizers/url.py
@@ -22,18 +22,27 @@ class URLMetadataNormalizer(BaseMetadataNormalizer):
     urls_platforms = {
         "ftp://ftp.remss.com/gmi": 'GPM',
         "ftp://anon-ftp.ceda.ac.uk/neodc/esacci/sst/": 'Earth Observation Satellites',
-        "ftp://ftp.gportal.jaxa.jp/standard/GCOM-W": 'GCOM-W1'}
+        "ftp://ftp.gportal.jaxa.jp/standard/GCOM-W": 'GCOM-W1',
+        "ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046":'GCOM-W1',
+        "ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003":'GCOM-W1',
+        "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024":'GCOM-W1'}
 
     urls_instruments = {
         'ftp://ftp.remss.com/gmi': 'GMI',
         'ftp://ftp.gportal.jaxa.jp/standard/GCOM-W/GCOM-W.AMSR2': 'AMSR2',
         'ftp://anon-ftp.ceda.ac.uk/neodc/esacci/sst/':
-        'Imaging Spectrometers/Radiometers', }
+        'Imaging Spectrometers/Radiometers',
+        "ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046":'GMI',
+        "ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003":'GMI',
+        "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024":'GMI'}
 
     urls_provider = {
         'ftp://anon-ftp.ceda.ac.uk/neodc/esacci/sst/data/CDR_v2/Climatology/L4/v2.1': 'ESA/CCI',
         "ftp://ftp.remss.com/gmi/": 'NASA/GSFC/SED/ESD/LA/GPM',
-        "ftp://ftp.gportal.jaxa.jp/standard": 'JP/JAXA/EOC'}
+        "ftp://ftp.gportal.jaxa.jp/standard": 'JP/JAXA/EOC',
+        "ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046":'ESA/CCI',
+        "ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003":'ESA/CCI',
+        "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024":'ESA/CCI'}
 
     urls_geometry = {'ftp://anon-ftp.ceda.ac.uk/neodc/esacci/sst/':
                      ('POLYGON((-180 -90, -180 90, 180 90, 180 -90, -180 -90))'),
@@ -42,14 +51,23 @@ class URLMetadataNormalizer(BaseMetadataNormalizer):
                      'ftp://ftp.gportal.jaxa.jp/standard/GCOM-W/GCOM-W.AMSR2/L3.SST_25':
                      ('POLYGON((-180 -90, -180 90, 180 90, 180 -90, -180 -90))'),
                      "ftp://ftp.remss.com/gmi/":
-                     ('POLYGON((-180 -90, -180 90, 180 90, 180 -90, -180 -90))')}
+                     ('POLYGON((-180 -90, -180 90, 180 90, 180 -90, -180 -90))'),
+                    "ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046":
+                    ('POLYGON((-180 -90, -180 90, 180 90, 180 -90, -180 -90))'),
+                    "ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003":
+                    ('POLYGON((-180 -90, -180 90, 180 90, 180 -90, -180 -90))'),
+                    "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024":
+                    ('POLYGON((-180 -90, -180 90, 180 90, 180 -90, -180 -90))')}
 
     urls_title = {
         'ftp://anon-ftp.ceda.ac.uk/neodc/esacci/sst/data/CDR_v2/Climatology/L4/v2.1': 'ESA SST CCI OSTIA L4 Climatology',
         "ftp://ftp.remss.com/gmi/": 'Atmosphere parameters from Global Precipitation Measurement Microwave Imager',
         "ftp://ftp.gportal.jaxa.jp/standard/GCOM-W/GCOM-W.AMSR2/L2.SST/": 'AMSR2-L2 Sea Surface Temperature',
         "ftp://ftp.gportal.jaxa.jp/standard/GCOM-W/GCOM-W.AMSR2/L3.SST_10/": 'AMSR2-L2 Sea Surface Temperature',
-        "ftp://ftp.gportal.jaxa.jp/standard/GCOM-W/GCOM-W.AMSR2/L3.SST_25/": 'AMSR2-L2 Sea Surface Temperature'
+        "ftp://ftp.gportal.jaxa.jp/standard/GCOM-W/GCOM-W.AMSR2/L3.SST_25/": 'AMSR2-L2 Sea Surface Temperature',
+        "ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046":'X',
+        "ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003":'X',
+        "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024":'X'
         }
 
     urls_entry_id = {"https://thredds.met.no/thredds/catalog/osisaf/met.no/ice":
@@ -73,7 +91,31 @@ class URLMetadataNormalizer(BaseMetadataNormalizer):
                 ['sea_surface_temperature'],
                 "ftp://ftp.remss.com/gmi/":
                 ['wind_speed', 'atmosphere_mass_content_of_water_vapor',
-                 'atmosphere_mass_content_of_cloud_liquid_water', 'rainfall_rate'], }
+                 'atmosphere_mass_content_of_cloud_liquid_water', 'rainfall_rate'],
+                "ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046":
+                #based on http://nrt.cmems-du.eu/motu-web/Motu?action=describeProduct&service=SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046-TDS&product=dataset-duacs-nrt-global-merged-allsat-phy-l4
+                ['surface_geostrophic_eastward_sea_water_velocity',
+                'surface_geostrophic_eastward_sea_water_velocity_assuming_sea_level_for_geoid',
+                'surface_geostrophic_northward_sea_water_velocity',
+                'surface_geostrophic_northward_sea_water_velocity_assuming_sea_level_for_geoid'],
+                "ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003":
+                # based on http://nrt.cmems-du.eu/motu-web/Motu?action=describeProduct&service=MULTIOBS_GLO_PHY_NRT_015_003-TDS&product=dataset-uv-nrt-daily
+                ['eastward_sea_water_velocity',
+                'northward_sea_water_velocity'],
+                "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024":
+                # based on http://nrt.cmems-du.eu/motu-web/Motu?action=describeProduct&service=GLOBAL_ANALYSIS_FORECAST_PHY_001_024-TDS&product=global-analysis-forecast-phy-001-024
+                #['sea_water_potential_temperature_at_sea_floor', # problematic for pti!! DANGER TODO
+                ['ocean_mixed_layer_thickness_defined_by_sigma_theta',
+                'sea_ice_area_fraction',
+                'sea_ice_thickness',
+                'sea_water_salinity',
+                'sea_water_potential_temperature',
+                'eastward_sea_water_velocity',
+                'eastward_sea_ice_velocity',
+                'northward_sea_water_velocity',
+                'northward_sea_ice_velocity',
+                'sea_surface_height_above_geoid']
+                }
 
     @staticmethod
     def find_matching_value(associated_dict, raw_attributes):
@@ -92,6 +134,20 @@ class URLMetadataNormalizer(BaseMetadataNormalizer):
         # tuple of all formats for usage of "strptime" function of datetime
         # Order of this tuple matters! so the more generic formats must be in the end of tuple
         strp_format = (
+            # for ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046/dataset-duacs-nrt-global-merged-allsat-phy-l4
+            "dataset-uv-nrt-hourly_%Y%m%dT%H%MZ",
+            "dataset-uv-nrt-monthly_%Y%mT%H%MZ",
+            "dataset-uv-nrt-daily_%Y%m%dT%H%MZ",
+            # for ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046/dataset-duacs-nrt-global-merged-allsat-phy-l4
+            "mercatorpsy4v3r1_gl12_so_%Y%m%d_%H",
+            "mercatorpsy4v3r1_gl12_thetao_%Y%m%d_%H",
+            "mercatorpsy4v3r1_gl12_uovo_%Y%m%d_%H",
+            "SMOC_%Y%m%d",
+            "mercatorpsy4v3r1_%Y%m%d",
+            "mercatorpsy4v3r1_%Y%m.nc",
+            # for ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046/dataset-duacs-nrt-global-merged-allsat-phy-l4
+            "nrt_global_allsat_phy_l4_%Y%m%d",# e.x.: 'nrt_global_allsat_phy_l4_20200206'
+            "mercatorpsy4v3r1_%Y%m%d",
             "f35_%Y%m%dv8.2_d3d.gz",
             "f35_%Y%m%dv8.2.gz",
             "f35_%Y%mv8.2.gz",
@@ -152,7 +208,25 @@ class URLMetadataNormalizer(BaseMetadataNormalizer):
                 'ftp://ftp.remss.com': file_name,
                 'ftp://anon-ftp.ceda.ac.uk/neodc/esacci/sst/data/CDR_v2/Climatology/L4/v2.1': "19820101" if start else "20100101",
                 "ftp://ftp.gportal.jaxa.jp/standard/GCOM-W/GCOM-W.AMSR2":
-                file_name_splitted[0] + '_' + file_name_splitted[1] if file_name_splitted else None
+                file_name_splitted[0] + '_' + file_name_splitted[1] if file_name_splitted else None,
+                "ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046/dataset-duacs-nrt-global-merged-allsat-phy-l4":
+                file_name[:33],
+                "ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003":
+                file_name_splitted[0] + '_' + file_name_splitted[1] if file_name_splitted else None,
+                "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024/global-analysis-forecast-phy-001-024/":
+                file_name_splitted[0] + '_' + file_name_splitted[-2]  if file_name_splitted else None,
+                "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024/global-analysis-forecast-phy-001-024-3dinst-so/":
+                file_name[:36],
+                "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024/global-analysis-forecast-phy-001-024-3dinst-thetao":
+                file_name[:40],
+                "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024/global-analysis-forecast-phy-001-024-3dinst-uovo":
+                file_name[:38],
+                "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024/global-analysis-forecast-phy-001-024-hourly-merged-uv":
+                file_name_splitted[0] + '_' + file_name_splitted[1]  if file_name_splitted else None,
+                "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024/global-analysis-forecast-phy-001-024-hourly-t-u-v-ssh/":
+                file_name_splitted[0] + '_' + file_name_splitted[-2]  if file_name_splitted else None,
+                "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024/global-analysis-forecast-phy-001-024-monthly/":
+                file_name_splitted[0] + '_' + file_name_splitted[-1]  if file_name_splitted else None
             }
             extracted_date = self.extract_time(self.find_matching_value(
                 url_time, raw_attributes))
@@ -184,6 +258,26 @@ class URLMetadataNormalizer(BaseMetadataNormalizer):
                 if file_name_splitted[1].endswith('00'):  # it is a month file
                     extracted_date = extracted_date if start else \
                         extracted_date + self.length_of_month(extracted_date)
+            elif raw_attributes['url'].startswith(
+                "ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046"):
+                extracted_date = extracted_date if start else extracted_date + relativedelta(days=1)
+            elif raw_attributes['url'].startswith('ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003'):
+                if "monthly" in file_name:
+                    extracted_date = extracted_date if start else \
+                        extracted_date + self.length_of_month(extracted_date)
+                if "hourly" in file_name or "daily" in file_name:
+                    extracted_date = extracted_date if start else \
+                        extracted_date + relativedelta(days=1)
+            elif raw_attributes['url'].startswith('ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024'):
+                if any(path_part.endswith("monthly") for path_part in url_path_and_file_name_splitted):
+                    extracted_date = extracted_date if start else \
+                        extracted_date + self.length_of_month(extracted_date)
+                elif any("3dinst" in path_part for path_part in url_path_and_file_name_splitted):
+                    extracted_date = extracted_date if start else \
+                        extracted_date + relativedelta(hours=6)
+                else:
+                    extracted_date = extracted_date if start else \
+                        extracted_date + relativedelta(days=1)
             return extracted_date
 
     def get_provider(self, raw_attributes):
@@ -218,8 +312,7 @@ class URLMetadataNormalizer(BaseMetadataNormalizer):
             for url_start in self.urls_entry_id:
                 if raw_attributes['url'].startswith(url_start):
                     try:
-                        file_name = re.search(
-                            self.urls_entry_id[url_start],raw_attributes['url']).group(1)
+                        file_name = self.urls_entry_id[url_start].search(raw_attributes['url']).group(1)
                     except AttributeError:
                         file_name = None
         return file_name

--- a/metanorm/normalizers/url.py
+++ b/metanorm/normalizers/url.py
@@ -2,7 +2,6 @@
 
 import calendar
 import logging
-import os
 import re
 from datetime import datetime
 from urllib.parse import urlparse
@@ -23,41 +22,36 @@ class URLMetadataNormalizer(BaseMetadataNormalizer):
         "ftp://ftp.remss.com/gmi": 'GPM',
         "ftp://anon-ftp.ceda.ac.uk/neodc/esacci/sst/": 'Earth Observation Satellites',
         "ftp://ftp.gportal.jaxa.jp/standard/GCOM-W": 'GCOM-W1',
-        "ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046":'X',
-        "ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003":'X',
-        "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024":'X'}
+        "ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046": 'X',
+        "ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003": 'X',
+        "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024": 'X'}
 
     urls_instruments = {
         'ftp://ftp.remss.com/gmi': 'GMI',
         'ftp://ftp.gportal.jaxa.jp/standard/GCOM-W/GCOM-W.AMSR2': 'AMSR2',
         'ftp://anon-ftp.ceda.ac.uk/neodc/esacci/sst/':
         'Imaging Spectrometers/Radiometers',
-        "ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046":'X',
-        "ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003":'X',
-        "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024":'X'}
+        "ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046": 'X',
+        "ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003": 'X',
+        "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024": 'X'}
 
     urls_provider = {
         'ftp://anon-ftp.ceda.ac.uk/neodc/esacci/sst/data/CDR_v2/Climatology/L4/v2.1': 'ESA/CCI',
         "ftp://ftp.remss.com/gmi/": 'NASA/GSFC/SED/ESD/LA/GPM',
         "ftp://ftp.gportal.jaxa.jp/standard": 'JP/JAXA/EOC',
-        "ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046":'X',
-        "ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003":'X',
-        "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024":'X'}
+        "ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046": 'X',
+        "ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003": 'X',
+        "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024": 'X'}
 
-    urls_geometry = {'ftp://anon-ftp.ceda.ac.uk/neodc/esacci/sst/':
-                     ('POLYGON((-180 -90, -180 90, 180 90, 180 -90, -180 -90))'),
-                     'ftp://ftp.gportal.jaxa.jp/standard/GCOM-W/GCOM-W.AMSR2/L3.SST_10':
-                     ('POLYGON((-180 -90, -180 90, 180 90, 180 -90, -180 -90))'),
-                     'ftp://ftp.gportal.jaxa.jp/standard/GCOM-W/GCOM-W.AMSR2/L3.SST_25':
-                     ('POLYGON((-180 -90, -180 90, 180 90, 180 -90, -180 -90))'),
-                     "ftp://ftp.remss.com/gmi/":
-                     ('POLYGON((-180 -90, -180 90, 180 90, 180 -90, -180 -90))'),
-                    "ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046":
-                    ('POLYGON((-180 -90, -180 90, 180 90, 180 -90, -180 -90))'),
-                    "ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003":
-                    ('POLYGON((-180 -90, -180 90, 180 90, 180 -90, -180 -90))'),
-                    "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024":
-                    ('POLYGON((-180 -90, -180 90, 180 90, 180 -90, -180 -90))')}
+    keys_for_geometry_dictionary = {'ftp://anon-ftp.ceda.ac.uk/neodc/esacci/sst/',
+                                    'ftp://ftp.gportal.jaxa.jp/standard/GCOM-W/GCOM-W.AMSR2/L3.SST_10',
+                                    'ftp://ftp.gportal.jaxa.jp/standard/GCOM-W/GCOM-W.AMSR2/L3.SST_25',
+                                    "ftp://ftp.remss.com/gmi/",
+                                    "ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046",
+                                    "ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003",
+                                    "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024"}
+    urls_geometry = dict.fromkeys(keys_for_geometry_dictionary,
+                                  ('POLYGON((-180 -90, -180 90, 180 90, 180 -90, -180 -90))'))
 
     urls_title = {
         'ftp://anon-ftp.ceda.ac.uk/neodc/esacci/sst/data/CDR_v2/Climatology/L4/v2.1': 'ESA SST CCI OSTIA L4 Climatology',
@@ -65,10 +59,10 @@ class URLMetadataNormalizer(BaseMetadataNormalizer):
         "ftp://ftp.gportal.jaxa.jp/standard/GCOM-W/GCOM-W.AMSR2/L2.SST/": 'AMSR2-L2 Sea Surface Temperature',
         "ftp://ftp.gportal.jaxa.jp/standard/GCOM-W/GCOM-W.AMSR2/L3.SST_10/": 'AMSR2-L2 Sea Surface Temperature',
         "ftp://ftp.gportal.jaxa.jp/standard/GCOM-W/GCOM-W.AMSR2/L3.SST_25/": 'AMSR2-L2 Sea Surface Temperature',
-        "ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046":'X',
-        "ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003":'X',
-        "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024":'X'
-        }
+        "ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046": 'X',
+        "ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003": 'X',
+        "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024": 'X'
+    }
 
     urls_entry_id = {"https://thredds.met.no/thredds/catalog/osisaf/met.no/ice":
                      re.compile(r"([^/]+)\.nc\.dods$"),
@@ -93,28 +87,28 @@ class URLMetadataNormalizer(BaseMetadataNormalizer):
                 ['wind_speed', 'atmosphere_mass_content_of_water_vapor',
                  'atmosphere_mass_content_of_cloud_liquid_water', 'rainfall_rate'],
                 "ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046":
-                #based on http://nrt.cmems-du.eu/motu-web/Motu?action=describeProduct&service=SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046-TDS&product=dataset-duacs-nrt-global-merged-allsat-phy-l4
+                # based on http://nrt.cmems-du.eu/motu-web/Motu?action=describeProduct&service=SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046-TDS&product=dataset-duacs-nrt-global-merged-allsat-phy-l4
                 ['surface_geostrophic_eastward_sea_water_velocity',
-                'surface_geostrophic_eastward_sea_water_velocity_assuming_sea_level_for_geoid',
-                'surface_geostrophic_northward_sea_water_velocity',
-                'surface_geostrophic_northward_sea_water_velocity_assuming_sea_level_for_geoid'],
+                 'surface_geostrophic_eastward_sea_water_velocity_assuming_sea_level_for_geoid',
+                 'surface_geostrophic_northward_sea_water_velocity',
+                 'surface_geostrophic_northward_sea_water_velocity_assuming_sea_level_for_geoid'],
                 "ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003":
                 # based on http://nrt.cmems-du.eu/motu-web/Motu?action=describeProduct&service=MULTIOBS_GLO_PHY_NRT_015_003-TDS&product=dataset-uv-nrt-daily
                 ['eastward_sea_water_velocity',
-                'northward_sea_water_velocity'],
+                 'northward_sea_water_velocity'],
                 "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024":
                 # based on http://nrt.cmems-du.eu/motu-web/Motu?action=describeProduct&service=GLOBAL_ANALYSIS_FORECAST_PHY_001_024-TDS&product=global-analysis-forecast-phy-001-024
-                #['sea_water_potential_temperature_at_sea_floor', # problematic for pti!! DANGER TODO
+                # ['sea_water_potential_temperature_at_sea_floor', # problematic for pti!! DANGER TODO
                 ['ocean_mixed_layer_thickness_defined_by_sigma_theta',
-                'sea_ice_area_fraction',
-                'sea_ice_thickness',
-                'sea_water_salinity',
-                'sea_water_potential_temperature',
-                'eastward_sea_water_velocity',
-                'eastward_sea_ice_velocity',
-                'northward_sea_water_velocity',
-                'northward_sea_ice_velocity',
-                'sea_surface_height_above_geoid']
+                 'sea_ice_area_fraction',
+                 'sea_ice_thickness',
+                 'sea_water_salinity',
+                 'sea_water_potential_temperature',
+                 'eastward_sea_water_velocity',
+                 'eastward_sea_ice_velocity',
+                 'northward_sea_water_velocity',
+                 'northward_sea_ice_velocity',
+                 'sea_surface_height_above_geoid']
                 }
 
     @staticmethod
@@ -146,7 +140,7 @@ class URLMetadataNormalizer(BaseMetadataNormalizer):
             "mercatorpsy4v3r1_%Y%m%d",
             "mercatorpsy4v3r1_%Y%m.nc",
             # for ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046/dataset-duacs-nrt-global-merged-allsat-phy-l4
-            "nrt_global_allsat_phy_l4_%Y%m%d",# e.x.: 'nrt_global_allsat_phy_l4_20200206'
+            "nrt_global_allsat_phy_l4_%Y%m%d",  # e.x.: 'nrt_global_allsat_phy_l4_20200206'
             "mercatorpsy4v3r1_%Y%m%d",
             # for remss
             "f35_%Y%m%dv8.2_d3d.gz",
@@ -186,9 +180,11 @@ class URLMetadataNormalizer(BaseMetadataNormalizer):
             return pti.get_gcmd_instrument(found_value)
 
     def get_time_coverage_start(self, raw_attributes):
+        """return the start time with "start" flag equals to "True" for the method."""
         return self.find_time_coverage(raw_attributes, start=True)
 
     def get_time_coverage_end(self, raw_attributes):
+        """return the end time with "start" flag equals to "False" for the method."""
         return self.find_time_coverage(raw_attributes, start=False)
 
     def find_time_coverage(self, raw_attributes, start):
@@ -215,7 +211,8 @@ class URLMetadataNormalizer(BaseMetadataNormalizer):
                 "ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003":
                 file_name_splitted[0] + '_' + file_name_splitted[1] if file_name_splitted else None,
                 "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024/global-analysis-forecast-phy-001-024/":
-                file_name_splitted[0] + '_' + file_name_splitted[-2]  if file_name_splitted else None,
+                file_name_splitted[0] + '_' +
+                    file_name_splitted[-2] if file_name_splitted else None,
                 "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024/global-analysis-forecast-phy-001-024-3dinst-so/":
                 file_name[:36],
                 "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024/global-analysis-forecast-phy-001-024-3dinst-thetao":
@@ -223,11 +220,12 @@ class URLMetadataNormalizer(BaseMetadataNormalizer):
                 "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024/global-analysis-forecast-phy-001-024-3dinst-uovo":
                 file_name[:38],
                 "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024/global-analysis-forecast-phy-001-024-hourly-merged-uv":
-                file_name_splitted[0] + '_' + file_name_splitted[1]  if file_name_splitted else None,
+                file_name_splitted[0] + '_' + file_name_splitted[1] if file_name_splitted else None,
                 "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024/global-analysis-forecast-phy-001-024-hourly-t-u-v-ssh/":
-                file_name_splitted[0] + '_' + file_name_splitted[-2]  if file_name_splitted else None,
+                file_name_splitted[0] + '_' +
+                    file_name_splitted[-2] if file_name_splitted else None,
                 "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024/global-analysis-forecast-phy-001-024-monthly/":
-                file_name_splitted[0] + '_' + file_name_splitted[-1]  if file_name_splitted else None
+                file_name_splitted[0] + '_' + file_name_splitted[-1] if file_name_splitted else None
             }
             extracted_date = self.extract_time(self.find_matching_value(
                 url_time, raw_attributes))
@@ -239,13 +237,13 @@ class URLMetadataNormalizer(BaseMetadataNormalizer):
                 # 'd3d' cases are the average of three consequent days! so start day is yesterday!
                 # if condition is the search of 'd3d' in the filename
                 if 'd3d' in file_name:
-                    d = -1 if start else 1
-                    extracted_date = extracted_date + relativedelta(days=d)
+                    relative_days = -1 if start else 1
+                    extracted_date = extracted_date + relativedelta(days=relative_days)
                 # for weekly average ones in the "weeks" folder
                 # if condition is the search of "weeks" folder in the FTP path
                 elif "weeks" in url_path_and_file_name_splitted:
-                    d = -3 if start else 3
-                    extracted_date = extracted_date + relativedelta(days=d)
+                    relative_days = -3 if start else 3
+                    extracted_date = extracted_date + relativedelta(days=relative_days)
                 elif re.search(r"^f35_[0-9]{6}v[0-9]\.[0-9]\.gz$", file_name):
                     # file is a month file.So,the end time must be the end of month.
                     # python "strptime" always gives the first day. So the length of month in that
@@ -260,7 +258,7 @@ class URLMetadataNormalizer(BaseMetadataNormalizer):
                     extracted_date = extracted_date if start else \
                         extracted_date + self.length_of_month(extracted_date)
             elif raw_attributes['url'].startswith(
-                "ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046"):
+                    "ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046"):
                 extracted_date = extracted_date if start else extracted_date + relativedelta(days=1)
             elif raw_attributes['url'].startswith('ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003'):
                 if "monthly" in file_name:
@@ -313,7 +311,8 @@ class URLMetadataNormalizer(BaseMetadataNormalizer):
             for url_start in self.urls_entry_id:
                 if raw_attributes['url'].startswith(url_start):
                     try:
-                        file_name = self.urls_entry_id[url_start].search(raw_attributes['url']).group(1)
+                        file_name = self.urls_entry_id[url_start].search(
+                            raw_attributes['url']).group(1)
                     except AttributeError:
                         file_name = None
         return file_name

--- a/metanorm/normalizers/url.py
+++ b/metanorm/normalizers/url.py
@@ -58,7 +58,7 @@ class URLMetadataNormalizer(BaseMetadataNormalizer):
         "ftp://ftp.remss.com/gmi/": 'Atmosphere parameters from Global Precipitation Measurement Microwave Imager',
         "ftp://ftp.gportal.jaxa.jp/standard/GCOM-W/GCOM-W.AMSR2/L2.SST/": 'AMSR2-L2 Sea Surface Temperature',
         "ftp://ftp.gportal.jaxa.jp/standard/GCOM-W/GCOM-W.AMSR2/L3.SST_10/": 'AMSR2-L2 Sea Surface Temperature',
-        "ftp://ftp.gportal.jaxa.jp/standard/GCOM-W/GCOM-W.AMSR2/L3.SST_25/": 'AMSR2-L2 Sea Surface Temperature',
+        "ftp://ftp.gportal.jaxa.jp/standard/GCOM-W/GCOM-W.AMSR2/L3.SST_25/": 'AMSR2-L3 Sea Surface Temperature',
         "ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046": 'GLOBAL OCEAN GRIDDED L4 SEA SURFACE HEIGHTS AND DERIVED VARIABLES NRT',
         "ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003": 'GLOBAL TOTAL SURFACE AND 15M CURRENT FROM ALTIMETRIC GEOSTROPHIC CURRENT AND MODELED EKMAN CURRENT PROCESSING',
         "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024": 'GLOBAL OCEAN 1_12 PHYSICS ANALYSIS AND FORECAST UPDATED DAILY'

--- a/metanorm/normalizers/url.py
+++ b/metanorm/normalizers/url.py
@@ -22,26 +22,26 @@ class URLMetadataNormalizer(BaseMetadataNormalizer):
         "ftp://ftp.remss.com/gmi": 'GPM',
         "ftp://anon-ftp.ceda.ac.uk/neodc/esacci/sst/": 'Earth Observation Satellites',
         "ftp://ftp.gportal.jaxa.jp/standard/GCOM-W": 'GCOM-W1',
-        "ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046": 'X',
-        "ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003": 'X',
-        "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024": 'X'}
+        "ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046": 'Earth Observation satellites',
+        "ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003": 'Earth Observation satellites',
+        "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024": 'OPERATIONAL MODELS'}
 
     urls_instruments = {
         'ftp://ftp.remss.com/gmi': 'GMI',
         'ftp://ftp.gportal.jaxa.jp/standard/GCOM-W/GCOM-W.AMSR2': 'AMSR2',
         'ftp://anon-ftp.ceda.ac.uk/neodc/esacci/sst/':
         'Imaging Spectrometers/Radiometers',
-        "ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046": 'X',
-        "ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003": 'X',
-        "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024": 'X'}
+        "ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046": 'altimeters',
+        "ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003": 'altimeters',
+        "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024": 'computer'}
 
     urls_provider = {
         'ftp://anon-ftp.ceda.ac.uk/neodc/esacci/sst/data/CDR_v2/Climatology/L4/v2.1': 'ESA/CCI',
         "ftp://ftp.remss.com/gmi/": 'NASA/GSFC/SED/ESD/LA/GPM',
         "ftp://ftp.gportal.jaxa.jp/standard": 'JP/JAXA/EOC',
-        "ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046": 'X',
-        "ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003": 'X',
-        "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024": 'X'}
+        "ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046": 'cmems',
+        "ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003": 'cmems',
+        "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024": 'cmems'}
 
     keys_for_geometry_dictionary = {'ftp://anon-ftp.ceda.ac.uk/neodc/esacci/sst/',
                                     'ftp://ftp.gportal.jaxa.jp/standard/GCOM-W/GCOM-W.AMSR2/L3.SST_10',
@@ -59,9 +59,9 @@ class URLMetadataNormalizer(BaseMetadataNormalizer):
         "ftp://ftp.gportal.jaxa.jp/standard/GCOM-W/GCOM-W.AMSR2/L2.SST/": 'AMSR2-L2 Sea Surface Temperature',
         "ftp://ftp.gportal.jaxa.jp/standard/GCOM-W/GCOM-W.AMSR2/L3.SST_10/": 'AMSR2-L2 Sea Surface Temperature',
         "ftp://ftp.gportal.jaxa.jp/standard/GCOM-W/GCOM-W.AMSR2/L3.SST_25/": 'AMSR2-L2 Sea Surface Temperature',
-        "ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046": 'X',
-        "ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003": 'X',
-        "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024": 'X'
+        "ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046": 'GLOBAL OCEAN GRIDDED L4 SEA SURFACE HEIGHTS AND DERIVED VARIABLES NRT',
+        "ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003": 'GLOBAL TOTAL SURFACE AND 15M CURRENT FROM ALTIMETRIC GEOSTROPHIC CURRENT AND MODELED EKMAN CURRENT PROCESSING',
+        "ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024": 'GLOBAL OCEAN 1_12 PHYSICS ANALYSIS AND FORECAST UPDATED DAILY'
     }
 
     urls_entry_id = {"https://thredds.met.no/thredds/catalog/osisaf/met.no/ice":

--- a/tests/normalizers/test_url.py
+++ b/tests/normalizers/test_url.py
@@ -306,6 +306,48 @@ class URLMetadataNormalizerTestCase(unittest.TestCase):
                          ('Long_Name', '')])
         )
 
+    def test_instrument_global_analysis_forecast_phy_001_024(self):
+        """instrument from URLMetadataNormalizer """
+        attributes = {
+            'url': 'ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024'}
+        self.assertEqual(
+            self.normalizer.get_instrument(attributes),
+            OrderedDict([('Category', 'In Situ/Laboratory Instruments'),
+                         ('Class', 'Data Analysis'),
+                         ('Type', 'Environmental Modeling'),
+                         ('Subtype', ''),
+                         ('Short_Name', 'Computer'),
+                         ('Long_Name', 'Computer')])
+        )
+
+    def test_instrument_multiobs_glo_phy_nrt_015_003(self):
+        """instrument from URLMetadataNormalizer """
+        attributes = {
+            'url': 'ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003'}
+        self.assertEqual(
+            self.normalizer.get_instrument(attributes),
+            OrderedDict([('Category', 'Earth Remote Sensing Instruments'),
+                         ('Class', 'Active Remote Sensing'),
+                         ('Type', 'Altimeters'),
+                         ('Subtype', ''),
+                         ('Short_Name', ''),
+                         ('Long_Name', '')])
+        )
+
+    def test_instrument_sealevel_glo_phy_l4_nrt_observations_008_046(self):
+        """instrument from URLMetadataNormalizer """
+        attributes = {
+            'url': 'ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046'}
+        self.assertEqual(
+            self.normalizer.get_instrument(attributes),
+            OrderedDict([('Category', 'Earth Remote Sensing Instruments'),
+                         ('Class', 'Active Remote Sensing'),
+                         ('Type', 'Altimeters'),
+                         ('Subtype', ''),
+                         ('Short_Name', ''),
+                         ('Long_Name', '')])
+        )
+
     def test_platform_jaxa(self):
         """platform from URLMetadataNormalizer """
         attributes = {
@@ -339,6 +381,42 @@ class URLMetadataNormalizerTestCase(unittest.TestCase):
                          ('Series_Entity', ''),
                          ('Short_Name', ''),
                          ('Long_Name', '')])
+        )
+
+    def test_platform_global_analysis_forecast_phy_001_024(self):
+        """platform from URLMetadataNormalizer """
+        attributes = {
+            'url': 'ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024'}
+        self.assertEqual(
+            self.normalizer.get_platform(attributes),
+            OrderedDict([('Category','Models/Analyses'),
+                        ('Series_Entity',''),
+                        ('Short_Name','OPERATIONAL MODELS'),
+                        ('Long_Name','')])
+        )
+
+    def test_platform_multiobs_glo_phy_nrt_015_003(self):
+        """platform from URLMetadataNormalizer """
+        attributes = {
+            'url': 'ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003'}
+        self.assertEqual(
+            self.normalizer.get_platform(attributes),
+            OrderedDict([('Category','Earth Observation Satellites'),
+                        ('Series_Entity',''),
+                        ('Short_Name',''),
+                        ('Long_Name','')])
+        )
+
+    def test_platform_sealevel_glo_phy_l4_nrt_observations_008_046(self):
+        """platform from URLMetadataNormalizer """
+        attributes = {
+            'url': 'ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046'}
+        self.assertEqual(
+            self.normalizer.get_platform(attributes),
+            OrderedDict([('Category','Earth Observation Satellites'),
+                        ('Series_Entity',''),
+                        ('Short_Name',''),
+                        ('Long_Name','')])
         )
 
     def test_provider_jaxa(self):
@@ -383,6 +461,51 @@ class URLMetadataNormalizerTestCase(unittest.TestCase):
                          ('Short_Name', 'ESA/CCI'),
                          ('Long_Name', 'Climate Change Initiative, European Space Agency'),
                          ('Data_Center_URL', '')])
+        )
+
+    def test_provider_global_analysis_forecast_phy_001_024(self):
+        """provider from URLMetadataNormalizer """
+        attributes = {
+            'url': 'ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024'}
+        self.assertEqual(
+            self.normalizer.get_provider(attributes),
+            OrderedDict([('Bucket_Level0','MULTINATIONAL ORGANIZATIONS'),
+                         ('Bucket_Level1',''),
+                         ('Bucket_Level2',''),
+                         ('Bucket_Level3',''),
+                         ('Short_Name','CMEMS'),
+                         ('Long_Name','Copernicus - Marine Environment Monitoring Service'),
+                         ('Data_Center_URL','')])
+        )
+
+    def test_provider_multiobs_glo_phy_nrt_015_003(self):
+        """provider from URLMetadataNormalizer """
+        attributes = {
+            'url': 'ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003'}
+        self.assertEqual(
+            self.normalizer.get_provider(attributes),
+            OrderedDict([('Bucket_Level0','MULTINATIONAL ORGANIZATIONS'),
+                         ('Bucket_Level1',''),
+                         ('Bucket_Level2',''),
+                         ('Bucket_Level3',''),
+                         ('Short_Name','CMEMS'),
+                         ('Long_Name','Copernicus - Marine Environment Monitoring Service'),
+                         ('Data_Center_URL','')])
+        )
+
+    def test_provider_sealevel_glo_phy_l4_nrt_observations_008_046(self):
+        """provider from URLMetadataNormalizer """
+        attributes = {
+            'url': 'ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046'}
+        self.assertEqual(
+            self.normalizer.get_provider(attributes),
+            OrderedDict([('Bucket_Level0','MULTINATIONAL ORGANIZATIONS'),
+                         ('Bucket_Level1',''),
+                         ('Bucket_Level2',''),
+                         ('Bucket_Level3',''),
+                         ('Short_Name','CMEMS'),
+                         ('Long_Name','Copernicus - Marine Environment Monitoring Service'),
+                         ('Data_Center_URL','')])
         )
 
     def test_dataset_parameters_jaxa(self):
@@ -568,6 +691,27 @@ class URLMetadataNormalizerTestCase(unittest.TestCase):
             'url': 'ftp://anon-ftp.ceda.ac.uk/neodc/esacci/sst/data/CDR_v2/Climatology/L4/v2.1/D365-ESACCI-L4_GHRSST-SSTdepth-OSTIA-GLOB_CDR2.1-v02.0-fv01.0.nc'}
         self.assertEqual(self.normalizer.get_entry_title(
             attributes), 'ESA SST CCI OSTIA L4 Climatology')
+
+    def test_entry_title_global_analysis_forecast_phy_001_024(self):
+        """entry_title from URLMetadataNormalizer """
+        attributes = {
+            'url': 'ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024'}
+        self.assertEqual(
+            self.normalizer.get_entry_title(attributes),'GLOBAL OCEAN 1_12 PHYSICS ANALYSIS AND FORECAST UPDATED DAILY')
+
+    def test_entry_title_multiobs_glo_phy_nrt_015_003(self):
+        """entry_title from URLMetadataNormalizer """
+        attributes = {
+            'url': 'ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003'}
+        self.assertEqual(
+            self.normalizer.get_entry_title(attributes),'GLOBAL TOTAL SURFACE AND 15M CURRENT FROM ALTIMETRIC GEOSTROPHIC CURRENT AND MODELED EKMAN CURRENT PROCESSING')
+
+    def test_entry_title_sealevel_glo_phy_l4_nrt_observations_008_046(self):
+        """entry_title from URLMetadataNormalizer """
+        attributes = {
+            'url': 'ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046'}
+        self.assertEqual(
+            self.normalizer.get_entry_title(attributes),'GLOBAL OCEAN GRIDDED L4 SEA SURFACE HEIGHTS AND DERIVED VARIABLES NRT')
 
     def test_entry_id_jaxa(self):
         """entry_id from URLMetadataNormalizer """

--- a/tests/normalizers/test_url.py
+++ b/tests/normalizers/test_url.py
@@ -62,6 +62,83 @@ class URLMetadataNormalizerTestCase(unittest.TestCase):
                 {'url': 'ftp://ftp.gportal.jaxa.jp/standard/GCOM-W/GCOM-W.AMSR2/L3.SST_25/3/2013/07/GW1AM2_20130700_01M_EQMA_L3SGSSTLB3300300.h5'}),
             datetime(year=2013, month=7, day=1, hour=0, minute=0, second=0, tzinfo=tzutc()))
 
+    def test_time_coverage_start_phy_001_024(self):
+        """shall return the propert starting time for hardcoded normalizer """
+        self.assertEqual(
+            self.normalizer.get_time_coverage_start(
+                {'url': 'ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024/global-analysis-forecast-phy-001-024/2016/03/mercatorpsy4v3r1_gl12_mean_20160303_R20160316.nc'}),
+            datetime(year=2016, month=3, day=3, hour=0, minute=0, second=0, tzinfo=tzutc()))
+
+    def test_time_coverage_start_phy_001_024_3dinst_so(self):
+        """shall return the propert starting time for hardcoded normalizer """
+        self.assertEqual(
+            self.normalizer.get_time_coverage_start(
+                {'url': 'ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024/global-analysis-forecast-phy-001-024-3dinst-so/2019/04/mercatorpsy4v3r1_gl12_so_20190403_18h_R20190404.nc'}),
+            datetime(year=2019, month=4, day=3, hour=18, minute=0, second=0, tzinfo=tzutc()))
+
+    def test_time_coverage_start_phy_001_024_3dinst_thetao(self):
+        """shall return the propert starting time for hardcoded normalizer """
+        self.assertEqual(
+            self.normalizer.get_time_coverage_start(
+                {'url': 'ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024/global-analysis-forecast-phy-001-024-3dinst-thetao/2020/04/mercatorpsy4v3r1_gl12_thetao_20200404_18h_R20200405.nc'}),
+            datetime(year=2020, month=4, day=4, hour=18, minute=0, second=0, tzinfo=tzutc()))
+
+    def test_time_coverage_start_phy_001_024_3dinst_uovo(self):
+        """shall return the propert starting time for hardcoded normalizer """
+        self.assertEqual(
+            self.normalizer.get_time_coverage_start(
+                {'url': 'ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024/global-analysis-forecast-phy-001-024-3dinst-uovo/2020/04/mercatorpsy4v3r1_gl12_uovo_20200403_06h_R20200404.nc'}),
+            datetime(year=2020, month=4, day=3, hour=6, minute=0, second=0, tzinfo=tzutc()))
+
+    def test_time_coverage_start_phy_001_024_hourly_merged_uv(self):
+        """shall return the propert starting time for hardcoded normalizer """
+        self.assertEqual(
+            self.normalizer.get_time_coverage_start(
+                {'url': 'ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024/global-analysis-forecast-phy-001-024-hourly-merged-uv/2019/05/SMOC_20190515_R20190516.nc'}),
+            datetime(year=2019, month=5, day=15, hour=0, minute=0, second=0, tzinfo=tzutc()))
+
+    def test_time_coverage_start_phy_001_024_hourly_t_u_v_ssh(self):
+        """shall return the propert starting time for hardcoded normalizer """
+        self.assertEqual(
+            self.normalizer.get_time_coverage_start(
+                {'url': 'ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024/global-analysis-forecast-phy-001-024-hourly-t-u-v-ssh/2020/05/mercatorpsy4v3r1_gl12_hrly_20200511_R20200520.nc'}),
+            datetime(year=2020, month=5, day=11, hour=0, minute=0, second=0, tzinfo=tzutc()))
+
+    def test_time_coverage_start_phy_001_024_monthly(self):
+        """shall return the propert starting time for hardcoded normalizer """
+        self.assertEqual(
+            self.normalizer.get_time_coverage_start(
+                {'url': 'ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024/global-analysis-forecast-phy-001-024-monthly/2018/mercatorpsy4v3r1_gl12_mean_201807.nc'}),
+            datetime(year=2018, month=7, day=1, hour=0, minute=0, second=0, tzinfo=tzutc()))
+
+    def test_time_coverage_start_sealevel_glo_phy_l4_nrt_observations_008_046(self):
+        """shall return the propert starting time for hardcoded normalizer """
+        self.assertEqual(
+            self.normalizer.get_time_coverage_start(
+                {'url': 'ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046/dataset-duacs-nrt-global-merged-allsat-phy-l4/2019/04/nrt_global_allsat_phy_l4_20190403_20200320.nc'}),
+            datetime(year=2019, month=4, day=3, hour=0, minute=0, second=0, tzinfo=tzutc()))
+
+    def test_time_coverage_start_multiobs_glo_phy_nrt_015_003_daily(self):
+        """shall return the propert starting time for hardcoded normalizer """
+        self.assertEqual(
+            self.normalizer.get_time_coverage_start(
+                {'url': 'ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003/dataset-uv-nrt-daily/2020/03/dataset-uv-nrt-daily_20200301T0000Z_P20200307T0000.nc'}),
+            datetime(year=2020, month=3, day=1, hour=0, minute=0, second=0, tzinfo=tzutc()))
+
+    def test_time_coverage_start_multiobs_glo_phy_nrt_015_003_monthly(self):
+        """shall return the propert starting time for hardcoded normalizer """
+        self.assertEqual(
+            self.normalizer.get_time_coverage_start(
+                {'url': 'ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003/dataset-uv-nrt-monthly/2020/dataset-uv-nrt-monthly_202004T0000Z_P20200506T0000.nc'}),
+            datetime(year=2020, month=4, day=1, hour=0, minute=0, second=0, tzinfo=tzutc()))
+
+    def test_time_coverage_start_multiobs_glo_phy_nrt_015_003_hourly(self):
+        """shall return the propert starting time for hardcoded normalizer """
+        self.assertEqual(
+            self.normalizer.get_time_coverage_start(
+                {'url': 'ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003/dataset-uv-nrt-hourly/2020/09/dataset-uv-nrt-hourly_20200906T1800Z_P20200918T0000.nc'}),
+            datetime(year=2020, month=9, day=6, hour=18, minute=0, second=0, tzinfo=tzutc()))
+
     def test_time_coverage_end_remss_single_day_file(self):
         """shall return the propert end time for hardcoded normalizer """
         self.assertEqual(
@@ -110,6 +187,83 @@ class URLMetadataNormalizerTestCase(unittest.TestCase):
             self.normalizer.get_time_coverage_end(
                 {'url': 'ftp://ftp.gportal.jaxa.jp/standard/GCOM-W/GCOM-W.AMSR2/L3.SST_25/3/2015/04/GW1AM2_20150400_01M_EQMD_L3SGSSTLB3300300.h5'}),
             datetime(year=2015, month=4, day=30, hour=0, minute=0, second=0, tzinfo=tzutc()))
+
+    def test_time_coverage_end_phy_001_024(self):
+        """shall return the propert starting time for hardcoded normalizer """
+        self.assertEqual(
+            self.normalizer.get_time_coverage_end(
+                {'url': 'ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024/global-analysis-forecast-phy-001-024/2016/03/mercatorpsy4v3r1_gl12_mean_20160303_R20160316.nc'}),
+            datetime(year=2016, month=3, day=4, hour=0, minute=0, second=0, tzinfo=tzutc()))
+
+    def test_time_coverage_end_phy_001_024_3dinst_so(self):
+        """shall return the propert starting time for hardcoded normalizer """
+        self.assertEqual(
+            self.normalizer.get_time_coverage_end(
+                {'url': 'ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024/global-analysis-forecast-phy-001-024-3dinst-so/2019/04/mercatorpsy4v3r1_gl12_so_20190403_18h_R20190404.nc'}),
+            datetime(year=2019, month=4, day=4, hour=0, minute=0, second=0, tzinfo=tzutc()))
+
+    def test_time_coverage_end_phy_001_024_3dinst_thetao(self):
+        """shall return the propert starting time for hardcoded normalizer """
+        self.assertEqual(
+            self.normalizer.get_time_coverage_end(
+                {'url': 'ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024/global-analysis-forecast-phy-001-024-3dinst-thetao/2020/04/mercatorpsy4v3r1_gl12_thetao_20200404_18h_R20200405.nc'}),
+            datetime(year=2020, month=4, day=5, hour=0, minute=0, second=0, tzinfo=tzutc()))
+
+    def test_time_coverage_end_phy_001_024_3dinst_uovo(self):
+        """shall return the propert starting time for hardcoded normalizer """
+        self.assertEqual(
+            self.normalizer.get_time_coverage_end(
+                {'url': 'ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024/global-analysis-forecast-phy-001-024-3dinst-uovo/2020/04/mercatorpsy4v3r1_gl12_uovo_20200403_06h_R20200404.nc'}),
+            datetime(year=2020, month=4, day=3, hour=12, minute=0, second=0, tzinfo=tzutc()))
+
+    def test_time_coverage_end_phy_001_024_hourly_merged_uv(self):
+        """shall return the propert starting time for hardcoded normalizer """
+        self.assertEqual(
+            self.normalizer.get_time_coverage_end(
+                {'url': 'ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024/global-analysis-forecast-phy-001-024-hourly-merged-uv/2019/05/SMOC_20190515_R20190516.nc'}),
+            datetime(year=2019, month=5, day=16, hour=0, minute=0, second=0, tzinfo=tzutc()))
+
+    def test_time_coverage_end_phy_001_024_hourly_t_u_v_ssh(self):
+        """shall return the propert starting time for hardcoded normalizer """
+        self.assertEqual(
+            self.normalizer.get_time_coverage_end(
+                {'url': 'ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024/global-analysis-forecast-phy-001-024-hourly-t-u-v-ssh/2020/05/mercatorpsy4v3r1_gl12_hrly_20200511_R20200520.nc'}),
+            datetime(year=2020, month=5, day=12, hour=0, minute=0, second=0, tzinfo=tzutc()))
+
+    def test_time_coverage_end_phy_001_024_monthly(self):
+        """shall return the propert starting time for hardcoded normalizer """
+        self.assertEqual(
+            self.normalizer.get_time_coverage_end(
+                {'url': 'ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024/global-analysis-forecast-phy-001-024-monthly/2018/mercatorpsy4v3r1_gl12_mean_201807.nc'}),
+            datetime(year=2018, month=7, day=31, hour=0, minute=0, second=0, tzinfo=tzutc()))
+
+    def test_time_coverage_end_sealevel_glo_phy_l4_nrt_observations_008_046(self):
+        """shall return the propert ending time for hardcoded normalizer """
+        self.assertEqual(
+            self.normalizer.get_time_coverage_end(
+                {'url': 'ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046/dataset-duacs-nrt-global-merged-allsat-phy-l4/2019/04/nrt_global_allsat_phy_l4_20190403_20200320.nc'}),
+            datetime(year=2019, month=4, day=4, hour=0, minute=0, second=0, tzinfo=tzutc()))
+
+    def test_time_coverage_end_multiobs_glo_phy_nrt_015_003_daily(self):
+        """shall return the propert ending time for hardcoded normalizer """
+        self.assertEqual(
+            self.normalizer.get_time_coverage_end(
+                {'url': 'ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003/dataset-uv-nrt-daily/2020/03/dataset-uv-nrt-daily_20200302T0000Z_P20200307T0000.nc'}),
+            datetime(year=2020, month=3, day=3, hour=0, minute=0, second=0, tzinfo=tzutc()))
+
+    def test_time_coverage_end_multiobs_glo_phy_nrt_015_003_monthly(self):
+        """shall return the propert ending time for hardcoded normalizer """
+        self.assertEqual(
+            self.normalizer.get_time_coverage_end(
+                {'url': 'ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003/dataset-uv-nrt-monthly/2020/dataset-uv-nrt-monthly_202004T0000Z_P20200506T0000.nc'}),
+            datetime(year=2020, month=4, day=30, hour=0, minute=0, second=0, tzinfo=tzutc()))
+
+    def test_time_coverage_end_multiobs_glo_phy_nrt_015_003_hourly(self):
+        """shall return the propert ending time for hardcoded normalizer """
+        self.assertEqual(
+            self.normalizer.get_time_coverage_end(
+                {'url': 'ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003/dataset-uv-nrt-hourly/2020/09/dataset-uv-nrt-hourly_20200906T0000Z_P20200918T0000.nc'}),
+            datetime(year=2020, month=9, day=7, hour=0, minute=0, second=0, tzinfo=tzutc()))
 
     def test_instrument_jaxa(self):
         """instrument from URLMetadataNormalizer """
@@ -285,6 +439,116 @@ class URLMetadataNormalizerTestCase(unittest.TestCase):
                           ('description', 'Sea surface temperature is usually abbreviated as "SST". It is the temperature of sea water near the surface (including the part under sea-ice, if any), and not the skin temperature, whose standard name is surface_temperature. For the temperature of sea water at a particular depth or layer, a data variable of sea_water_temperature with a vertical coordinate axis should be used.')]), ]
         )
 
+    def test_dataset_parameters_phy_001_024(self):
+        """dataset_parameters from URLMetadataNormalizer """
+        attributes = {
+            'url': 'ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024'}
+        self.assertEqual(
+            self.normalizer.get_dataset_parameters(attributes),
+            [
+                OrderedDict([('standard_name', 'ocean_mixed_layer_thickness_defined_by_sigma_theta'),
+                             ('canonical_units', 'm'),
+                             ('grib', ''),
+                             ('amip', ''),
+                             ('description', 'The ocean mixed layer is the upper part of the ocean, regarded as being well-mixed. The base of the mixed layer defined by temperature, sigma or sigma_theta is the level at which the quantity indicated differs from its surface value by a certain amount.')]),
+                OrderedDict([('standard_name', 'sea_ice_area_fraction'),
+                             ('canonical_units', '1'),
+                             ('grib', '91'),
+                             ('amip', 'sic'),
+                             ('description', '"X_area_fraction" means the fraction of horizontal area occupied by X. "X_area" means the horizontal area occupied by X within the grid cell. Sea ice area fraction is area of the sea surface occupied by sea ice. It is also called "sea ice concentration".')]),
+                OrderedDict([('standard_name', 'sea_ice_thickness'),
+                             ('canonical_units', 'm'),
+                             ('grib', '92'),
+                             ('amip', 'sit'),
+                             ('description', 'The surface temperature is the (skin) temperature at the interface, not the bulk temperature of the medium above or below.  "Sea ice surface temperature" is the temperature that exists at the interface of sea ice and an overlying medium which may be air or snow.  In areas of snow covered sea ice, sea_ice_surface_temperature is not the same as the quantity with standard name surface_temperature.')]),
+                OrderedDict([('standard_name', 'sea_water_salinity'),
+                             ('canonical_units', '1e-3'),
+                             ('grib', '88'),
+                             ('amip', 'so'),
+                             ('description', 'Sea water salinity is the salt content of sea water, often on the Practical Salinity Scale of 1978. However, the unqualified term \'salinity\' is generic and does not necessarily imply any particular method of calculation. The units of salinity are dimensionless and the units attribute should normally be given as 1e-3 or 0.001 i.e. parts per thousand. There are standard names for the more precisely defined salinity quantities: sea_water_knudsen_salinity, S_K (used for salinity observations between 1901 and 1966),  sea_water_cox_salinity, S_C (used for salinity observations between 1967 and 1977), sea_water_practical_salinity, S_P (used for salinity observations from 1978 to the present day), sea_water_absolute_salinity, S_A, sea_water_preformed_salinity, S_*, and sea_water_reference_salinity. Practical Salinity is reported on the Practical Salinity Scale of 1978 (PSS-78), and is usually based on the electrical conductivity of sea water in observations since the 1960s. Conversion of data between the observed scales follows: S_P = (S_K - 0.03) * (1.80655 / 1.805) and S_P = S_C, however the accuracy of the latter is dependent on whether chlorinity or conductivity was used to determine the S_C value, with this inconsistency driving the development of PSS-78. The more precise standard names should be used where appropriate for both modelled and observed salinities. In particular, the use of sea_water_salinity to describe salinity observations made from 1978 onwards is now deprecated in favor of the term sea_water_practical_salinity which is the salinity quantity stored by national data centers for post-1978 observations. The only exception to this is where the observed salinities are definitely known not to be recorded on the Practical Salinity Scale. The unit "parts per thousand" was used for sea_water_knudsen_salinity and sea_water_cox_salinity.')]),
+                OrderedDict([('standard_name', 'sea_water_potential_temperature'),
+                             ('canonical_units', 'K'),
+                             ('grib', ''),
+                             ('amip', ''),
+                             ('description', 'Potential temperature is the temperature a parcel of air or sea water would have if moved adiabatically to sea level pressure.')]),
+                OrderedDict([('standard_name', 'eastward_sea_water_velocity'),
+                             ('canonical_units', 'm s-1'),
+                             ('grib', '49'),
+                             ('amip', ''),
+                             ('description', 'A velocity is a vector quantity. "Eastward" indicates a vector component which is positive when directed eastward (negative westward).')]),
+                OrderedDict([('standard_name', 'eastward_sea_ice_velocity'),
+                             ('canonical_units', 'm s-1'),
+                             ('grib', '95'),
+                             ('amip', ''),
+                             ('description', 'A velocity is a vector quantity. "Eastward" indicates a vector component which is positive when directed eastward (negative westward). Sea ice velocity is defined as a two-dimensional vector, with no vertical component.')]),
+                OrderedDict([('standard_name', 'northward_sea_water_velocity'),
+                             ('canonical_units', 'm s-1'),
+                             ('grib', '50'),
+                             ('amip', ''),
+                             ('description', 'A velocity is a vector quantity. "Northward" indicates a vector component which is positive when directed northward (negative southward).')]),
+                OrderedDict([('standard_name', 'northward_sea_ice_velocity'),
+                             ('canonical_units', 'm s-1'),
+                             ('grib', '96'),
+                             ('amip', ''),
+                             ('description', 'A velocity is a vector quantity. "Northward" indicates a vector component which is positive when directed northward (negative southward). Sea ice velocity is defined as a two-dimensional vector, with no vertical component.')]),
+                OrderedDict([('standard_name', 'sea_surface_height_above_geoid'),
+                             ('canonical_units', 'm'),
+                             ('grib', ''),
+                             ('amip', ''),
+                             ('description', 'The geoid is a surface of constant geopotential with which mean sea level would coincide if the ocean were at rest. (The volume enclosed between the geoid and the sea floor equals the mean volume of water in the ocean.) In an ocean GCM the geoid is the surface of zero depth, or the rigid lid if the model uses that approximation. "Sea surface height" is a time-varying quantity. By definition of the geoid, the global average of the time-mean sea surface height (i.e. mean sea level) above the geoid must be zero. The standard name for the height of the sea surface above mean sea level is sea_surface_height_above_sea_level. The standard name for the height of the sea surface above the reference ellipsoid is sea_surface_height_above_reference_ellipsoid.')])
+            ]
+        )
+
+    def test_dataset_parameters_multiobs_glo_phy_nrt_015_003(self):
+        """dataset_parameters from URLMetadataNormalizer """
+        attributes = {
+            'url': 'ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003'}
+        self.assertEqual(
+            self.normalizer.get_dataset_parameters(attributes),
+            [
+                OrderedDict([('standard_name', 'eastward_sea_water_velocity'),
+                             ('canonical_units', 'm s-1'),
+                             ('grib', '49'),
+                             ('amip', ''),
+                             ('description', 'A velocity is a vector quantity. "Eastward" indicates a vector component which is positive when directed eastward (negative westward).')]),
+                OrderedDict([('standard_name', 'northward_sea_water_velocity'),
+                             ('canonical_units', 'm s-1'),
+                             ('grib', '50'),
+                             ('amip', ''),
+                             ('description', 'A velocity is a vector quantity. "Northward" indicates a vector component which is positive when directed northward (negative southward).')]),
+            ]
+        )
+
+    def test_dataset_parameters_sealevel_glo_phy_l4_nrt_observations_008_046(self):
+        """dataset_parameters from URLMetadataNormalizer """
+        attributes = {
+            'url': 'ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046'}
+        self.assertEqual(
+            self.normalizer.get_dataset_parameters(attributes),
+            [
+                OrderedDict([('standard_name', 'surface_geostrophic_eastward_sea_water_velocity'),
+                             ('canonical_units', 'm s-1'),
+                             ('grib', ''),
+                             ('amip', ''),
+                             ('description', 'The surface called "surface" means the lower boundary of the atmosphere. A velocity is a vector quantity. "Eastward" indicates a vector component which is positive when directed eastward (negative westward). "Geostrophic" indicates that geostrophic balance is assumed. "Water" means water in all phases. surface_geostrophic_eastward_sea_water_velocity is the sum of a variable part, surface_geostrophic_eastward_sea_water_velocity_assuming_sea_level_for_geoid, and a constant part due to the stationary component of ocean circulation.')]),
+                OrderedDict([('standard_name', 'surface_geostrophic_eastward_sea_water_velocity_assuming_sea_level_for_geoid'),
+                             ('canonical_units', 'm s-1'),
+                             ('grib', ''),
+                             ('amip', ''),
+                             ('description', 'The surface called "surface" means the lower boundary of the atmosphere. A velocity is a vector quantity. "Eastward" indicates a vector component which is positive when directed eastward (negative westward). "Geostrophic" indicates that geostrophic balance is assumed. "Water" means water in all phases. "sea_level" means mean sea level. The geoid is a surface of constant geopotential with which mean sea level would coincide if the ocean were at rest. surface_geostrophic_eastward_sea_water_velocity_assuming_sea_level_for_geoid is the variable part of surface_geostrophic_eastward_sea_water_velocity. The assumption that sea level is equal to the geoid means that the stationary component of ocean circulation is equal to zero.')]),
+                OrderedDict([('standard_name', 'surface_geostrophic_northward_sea_water_velocity'),
+                             ('canonical_units', 'm s-1'),
+                             ('grib', ''),
+                             ('amip', ''),
+                             ('description', 'The surface called "surface" means the lower boundary of the atmosphere. A velocity is a vector quantity. "Northward" indicates a vector component which is positive when directed northward (negative southward). "Geostrophic" indicates that geostrophic balance is assumed. "Water" means water in all phases. surface_geostrophic_northward_sea_water_velocity is the sum of a variable part, surface_geostrophic_northward_sea_water_velocity_assuming_sea_level_for_geoid, and a constant part due to the stationary component of ocean circulation.')]),
+                OrderedDict([('standard_name', 'surface_geostrophic_northward_sea_water_velocity_assuming_sea_level_for_geoid'),
+                             ('canonical_units', 'm s-1'),
+                             ('grib', ''),
+                             ('amip', ''),
+                             ('description', 'The surface called "surface" means the lower boundary of the atmosphere. A velocity is a vector quantity. "Northward" indicates a vector component which is positive when directed northward (negative southward). "Geostrophic" indicates that geostrophic balance is assumed. "Water" means water in all phases. "sea_level" means mean sea level. The geoid is a surface of constant geopotential with which mean sea level would coincide if the ocean were at rest. surface_geostrophic_northward_sea_water_velocity_assuming_sea_level_for_geoid is the variable part of surface_geostrophic_northward_sea_water_velocity. The assumption that sea level is equal to the geoid means that the stationary component of ocean circulation is equal to zero.')])
+            ]
+        )
+
     def test_entry_title_jaxa(self):
         """entry_title from URLMetadataNormalizer """
         attributes = {
@@ -332,7 +596,6 @@ class URLMetadataNormalizerTestCase(unittest.TestCase):
         self.assertEqual(self.normalizer.get_entry_id(
             attributes), None)
 
-
     def test_entry_id_for_osisaf_ingester(self):
         """entry_id from URLMetadataNormalizer for osisaf project """
         attributes = {
@@ -344,6 +607,13 @@ class URLMetadataNormalizerTestCase(unittest.TestCase):
         """entry_id from URLMetadataNormalizer for PODAAC metadata"""
         attributes = {
             'url': "https://opendap.jpl.nasa.gov/opendap/Some/path/to/file/20180110000000-OSPO-L2P_GHRSST-SSTsubskin-VIIRS_NPP-ACSPO_V2.61-v02.0-fv01.0.nc"}
+        self.assertEqual(self.normalizer.get_entry_id(
+            attributes), '20180110000000-OSPO-L2P_GHRSST-SSTsubskin-VIIRS_NPP-ACSPO_V2.61-v02.0-fv01.0')
+
+    def test_entry_id_for_marine_copernicus(self):
+        """entry_id from URLMetadataNormalizer for marine copernicus metadata"""
+        attributes = {
+            'url': "ftp://nrt.cmems-du.eu/Core/Some/path/to/file/20180110000000-OSPO-L2P_GHRSST-SSTsubskin-VIIRS_NPP-ACSPO_V2.61-v02.0-fv01.0.nc"}
         self.assertEqual(self.normalizer.get_entry_id(
             attributes), '20180110000000-OSPO-L2P_GHRSST-SSTsubskin-VIIRS_NPP-ACSPO_V2.61-v02.0-fv01.0')
 
@@ -363,12 +633,37 @@ class URLMetadataNormalizerTestCase(unittest.TestCase):
             self.normalizer.get_location_geometry(attributes),
             'POLYGON((-180 -90, -180 90, 180 90, 180 -90, -180 -90))')
 
+    def test_geometry_phy_001_024(self):
+        """geometry from URLMetadataNormalizer """
+        attributes = {
+            'url': 'ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_PHY_001_024'}
+        self.assertEqual(
+            self.normalizer.get_location_geometry(attributes),
+            'POLYGON((-180 -90, -180 90, 180 90, 180 -90, -180 -90))')
+
+    def test_geometry_multiobs_glo_phy_nrt_015_003(self):
+        """geometry from URLMetadataNormalizer """
+        attributes = {
+            'url': 'ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003'}
+        self.assertEqual(
+            self.normalizer.get_location_geometry(attributes),
+            'POLYGON((-180 -90, -180 90, 180 90, 180 -90, -180 -90))')
+
+    def test_geometry_sealevel_glo_phy_l4_nrt_observations_008_046(self):
+        """geometry from URLMetadataNormalizer """
+        attributes = {
+            'url': 'ftp://nrt.cmems-du.eu/Core/SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046'}
+        self.assertEqual(
+            self.normalizer.get_location_geometry(attributes),
+            'POLYGON((-180 -90, -180 90, 180 90, 180 -90, -180 -90))')
+
     def test_geometry_remss(self):
         """geometry from URLMetadataNormalizer """
         attributes = {'url': 'ftp://ftp.remss.com/gmi/bmaps_v08.2/y2014/m06/'}
         self.assertEqual(
             self.normalizer.get_location_geometry(attributes),
             'POLYGON((-180 -90, -180 90, 180 90, 180 -90, -180 -90))')
+
     def test_geometry_ceda(self):
         """geometry from URLMetadataNormalizer """
         attributes = {

--- a/tests/normalizers/test_url.py
+++ b/tests/normalizers/test_url.py
@@ -677,7 +677,7 @@ class URLMetadataNormalizerTestCase(unittest.TestCase):
         attributes = {
             'url': 'ftp://ftp.gportal.jaxa.jp/standard/GCOM-W/GCOM-W.AMSR2/L3.SST_25/3/2012/07/GW1AM2_201207031905_134D_L2SGSSTLB3300300.h5'}
         self.assertEqual(
-            self.normalizer.get_entry_title(attributes), 'AMSR2-L2 Sea Surface Temperature')
+            self.normalizer.get_entry_title(attributes), 'AMSR2-L3 Sea Surface Temperature')
 
     def test_entry_title_remss(self):
         """entry_title from URLMetadataNormalizer """


### PR DESCRIPTION
@aperrin66 
@akorosov 
For three products (which mentioned here:https://github.com/nansencenter/metanorm/issues/29#issue-702619279) that are provided here:
https://resources.marine.copernicus.eu/?option=com_csw&view=details&product_id=GLOBAL_ANALYSIS_FORECAST_PHY_001_024
https://resources.marine.copernicus.eu/?option=com_csw&view=details&product_id=MULTIOBS_GLO_PHY_NRT_015_003
and
https://resources.marine.copernicus.eu/?option=com_csw&view=details&product_id=SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046

there is a needed for hardcoded values. Still the correctness from remote sensing is missing. I have fillied the some values and the replace them with `'X'` in order to easily recognizable for the review. Please, @akorosov once again fill in the correct `instruments` and `platform` and `provider` and `entry_title` for these. In the mean time, I start writing some tests for the time methods. And then we can write some tests for instruments,etc. after you (@akorosov ) tell me which one is which!!

One of the dataset parameters named 'sea_water_potential_temperature_at_sea_floor' is problematic and pti does not respond to its name. Please give me a solution for it as well.

So, please review it from this point of view at your earliest convenience.

I will convert it to a complete PR after writing the test. However, I need that remote sensing values as soon as possible now.