### PR TITLE
Issue40 url time coverage

### DIFF
--- a/metanorm/normalizers/url.py
+++ b/metanorm/normalizers/url.py
@@ -290,8 +290,7 @@ class URLMetadataNormalizer(BaseMetadataNormalizer):
                 for matcher, get_time, get_coverage in time_finder:
                     match = matcher.search(raw_attributes['url'])
                     if match:
-                        time_info = match.groupdict()
-                        file_time = get_time(**time_info)
+                        file_time = get_time(**match.groupdict())
                         return (get_coverage(file_time)[0], get_coverage(file_time)[1])
         return (None, None)
 

--- a/metanorm/utils.py
+++ b/metanorm/utils.py
@@ -1,6 +1,8 @@
 """Utility functions for metadata normalizing"""
 
 from collections import OrderedDict
+from datetime import datetime, timedelta
+from dateutil.tz import tzutc
 
 import pythesint as pti
 
@@ -157,3 +159,27 @@ def get_cf_or_wkv_standard_name(keyword):
     except IndexError:
         result_values = pti.get_wkv_variable(keyword)
     return result_values
+
+
+YEARMONTH_REGEX = r'(?P<year>\d{4})(?P<month>\d{2})'
+YEARMONTHDAY_REGEX = YEARMONTH_REGEX + r'(?P<day>\d{2})'
+
+def create_datetime(year, month=1, day=1, day_of_year=None, hour=0, minute=0, second=0):
+    """Returns a datetime object using the provided arguments.
+    Possible argument combinations are:
+      - year, month, day(, hour, minute, second)
+      - year, day_of_year(, hour, minute, second)
+    """
+    year = int(year)
+    hour = int(hour)
+    minute = int(minute)
+    second = int(second)
+
+    if day_of_year:
+        day_of_year = int(day_of_year)
+        first_day = datetime(year, 1, 1, hour, minute, second).replace(tzinfo=tzutc())
+        return first_day + timedelta(days=day_of_year-1)
+    else:
+        month = int(month)
+        day = int(day)
+        return datetime(year, month, day, hour, minute, second).replace(tzinfo=tzutc())

--- a/tests/normalizers/test_url.py
+++ b/tests/normalizers/test_url.py
@@ -136,15 +136,15 @@ class URLMetadataNormalizerTestCase(unittest.TestCase):
         """shall return the propert starting time for hardcoded normalizer """
         self.assertEqual(
             self.normalizer.get_time_coverage_start(
-                {'url': 'ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003/dataset-uv-nrt-hourly/2020/09/dataset-uv-nrt-hourly_20200906T1800Z_P20200918T0000.nc'}),
-            datetime(year=2020, month=9, day=6, hour=18, minute=0, second=0, tzinfo=tzutc()))
+                {'url': 'ftp://nrt.cmems-du.eu/Core/MULTIOBS_GLO_PHY_NRT_015_003/dataset-uv-nrt-hourly/2020/09/dataset-uv-nrt-hourly_20200906T0000Z_P20200912T0000.nc'}),
+            datetime(year=2020, month=9, day=6, hour=0, minute=0, second=0, tzinfo=tzutc()))
 
     def test_time_coverage_end_remss_single_day_file(self):
         """shall return the propert end time for hardcoded normalizer """
         self.assertEqual(
             self.normalizer.get_time_coverage_end(
                 {'url': 'ftp://ftp.remss.com/gmi/bmaps_v08.2/y2014/m06/f35_20140620v8.2.gz'}),
-            datetime(year=2014, month=6, day=20, hour=0, minute=0, second=0, tzinfo=tzutc()))
+            datetime(year=2014, month=6, day=21, hour=0, minute=0, second=0, tzinfo=tzutc()))
 
     def test_time_coverage_end_remss_month_file(self):
         """shall return the propert end time for hardcoded normalizer """
@@ -179,7 +179,7 @@ class URLMetadataNormalizerTestCase(unittest.TestCase):
         self.assertEqual(
             self.normalizer.get_time_coverage_end(
                 {'url': 'ftp://ftp.gportal.jaxa.jp/standard/GCOM-W/GCOM-W.AMSR2/L3.SST_25/3/2015/04/GW1AM2_20150401_01D_EQOD_L3SGSSTLB3300300.h5'}),
-            datetime(year=2015, month=4, day=1, hour=0, minute=0, second=0, tzinfo=tzutc()))
+            datetime(year=2015, month=4, day=2, hour=0, minute=0, second=0, tzinfo=tzutc()))
 
     def test_time_coverage_end_jaxa_month_file(self):
         """shall return the propert end time for hardcoded normalizer """

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,56 @@
+import re
+import unittest
+from datetime import datetime
+
+from dateutil.tz import tzutc
+
+import metanorm.utils as utils
+
+class TimeTestCase(unittest.TestCase):
+    """Tests for utilities dealing with time"""
+
+    def test_create_datetime_year_month_day(self):
+        """test create_datetime with a year, month and day"""
+        self.assertEqual(
+            utils.create_datetime(2020, 10, 15),
+            datetime(2020, 10, 15).replace(tzinfo=tzutc())
+        )
+
+    def test_create_datetime_year_day_of_year(self):
+        """test create_datetime with a year and day of year"""
+        self.assertEqual(
+            utils.create_datetime(2020, day_of_year=35),
+            datetime(2020, 2, 4).replace(tzinfo=tzutc())
+        )
+
+    def test_create_datetime_year_month_day_time(self):
+        """test create_datetime with a year, month, day and time"""
+        self.assertEqual(
+            utils.create_datetime(2020, 10, 15, hour=10, minute=25, second=38),
+            datetime(2020, 10, 15, 10, 25, 38).replace(tzinfo=tzutc())
+        )
+
+    def test_create_datetime_year_day_of_year_time(self):
+        """test create_datetime with a year, day of year and time"""
+        self.assertEqual(
+            utils.create_datetime(2020, day_of_year=35, hour=23, minute=1, second=40),
+            datetime(2020, 2, 4, 23, 1, 40).replace(tzinfo=tzutc())
+        )
+
+    def test_yearmonth_regex(self):
+        """The YEARMONTH_REGEX should provide a 'year' and 'month'
+        named groups
+        """
+        self.assertDictEqual(
+            re.match(utils.YEARMONTH_REGEX, '202010').groupdict(),
+            {'year': '2020', 'month': '10'}
+        )
+
+    def test_yearmonthday_regex(self):
+        """The YEARMONTHDAY_REGEX should provide a 'year', 'month'
+        and 'day' named groups
+        """
+        self.assertDictEqual(
+            re.match(utils.YEARMONTHDAY_REGEX, '20201017').groupdict(),
+            {'year': '2020', 'month': '10', 'day': '17'}
+        )


### PR DESCRIPTION
Resolves #40 

The information about time coverage for each URL is now stored in a single location: the `urls_time` dictionary.

Also fixed some wrong time coverage ends (see unit tests).