### PR TITLE
Add support for TOPAZ products

### DIFF
--- a/.github/workflows/tests_and_build.yml
+++ b/.github/workflows/tests_and_build.yml
@@ -16,7 +16,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASS }}

--- a/.github/workflows/tests_and_build.yml
+++ b/.github/workflows/tests_and_build.yml
@@ -2,7 +2,7 @@
 name: "Unit tests and builds"
 on: push
 env:
-  BASE_IMAGE_NAME: "${{ secrets.DOCKER_ORG }}/nansat_base:2.0.3-slim"
+  BASE_IMAGE_NAME: "${{ secrets.DOCKER_ORG }}/nansat_base:2.1.3-slim"
   TESTING_IMAGE_NAME: metanorm_tests
 jobs:
   tests_build:

--- a/.github/workflows/tests_and_build.yml
+++ b/.github/workflows/tests_and_build.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Login to DockerHub
         uses: docker/login-action@v2
@@ -31,7 +31,7 @@ jobs:
 
       - name: Build testing image
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: ./docker
           file: ./docker/Dockerfile_tests

--- a/docker/Dockerfile_tests
+++ b/docker/Dockerfile_tests
@@ -6,24 +6,6 @@ RUN pip install --no-cache-dir \
     setuptools \
     wheel
 
-RUN python -c 'import pythesint; pythesint.update_all_vocabularies( \
-{ \
-    "gcmd_instrument": "9.1.5", \
-    "gcmd_science_keyword": "9.1.5", \
-    "gcmd_provider": "9.1.5", \
-    "gcmd_platform": "9.1.5", \
-    "gcmd_location": "9.1.5", \
-    "gcmd_horizontalresolutionrange": "9.1.5", \
-    "gcmd_verticalresolutionrange": "9.1.5", \
-    "gcmd_temporalresolutionrange": "9.1.5", \
-    "gcmd_project": "9.1.5", \
-    "gcmd_rucontenttype": "9.1.5", \
-    "mmd_access_constraints": "v3.2", \
-    "mmd_activity_type": "v3.2", \
-    "mmd_areas": "v3.2", \
-    "mmd_operstatus": "v3.2", \
-    "mmd_platform_type": "v3.2", \
-    "mmd_use_constraint_type": "v3.2", \
-})'
+RUN python -c 'import pythesint; pythesint.update_all_vocabularies()'
 
 WORKDIR /src

--- a/metanorm/normalizers/geospaas/cmems.py
+++ b/metanorm/normalizers/geospaas/cmems.py
@@ -1,6 +1,8 @@
 """Normalizers for the metadata of CMEMS datasets"""
 
 import re
+from datetime import datetime
+
 from dateutil.relativedelta import relativedelta
 
 import metanorm.utils as utils
@@ -363,6 +365,77 @@ class CMEMS005001MetadataNormalizer(CMEMSMetadataNormalizer):
         return []
 
 
+class CMEMS002003MetadataNormalizer(CMEMSMetadataNormalizer):
+    """Normalizer for the ARCTIC_MULTIYEAR_PHY_002_003 product"""
+
+    url_prefix = 'ftp://my.cmems-du.eu/Core/ARCTIC_MULTIYEAR_PHY_002_003'
+    time_patterns = (
+        (
+            re.compile(rf"/{utils.YEARMONTHDAY_REGEX}_dm-12km-NERSC-MODEL-TOPAZ4B-ARC-RAN.*\.nc"),
+            utils.create_datetime,
+            lambda time: (time, time + relativedelta(days=1))
+        ),
+        (
+            re.compile(rf"/{utils.YEARMONTHDAY_REGEX}_mm-12km-NERSC-MODEL-TOPAZ4B-ARC-RAN.*\.nc"),
+            utils.create_datetime,
+            lambda time: (
+                datetime(time.year, time.month, 1, tzinfo=time.tzinfo),
+                datetime(time.year, time.month, 1, tzinfo=time.tzinfo) + relativedelta(months=1))
+        ),
+        (
+            re.compile(rf"/{utils.YEARMONTHDAY_REGEX}_ym-12km-NERSC-MODEL-TOPAZ4B-ARC-RAN.*\.nc"),
+            utils.create_datetime,
+            lambda time: (time, time + relativedelta(years=1))
+        ),
+    )
+
+    def get_entry_title(self, raw_metadata):
+        return 'Arctic Ocean Physics Reanalysis'
+
+    def get_summary(self, raw_metadata):
+        return utils.dict_to_string({
+            utils.SUMMARY_FIELDS['description']:
+                'The current version of the TOPAZ system - TOPAZ4b - is nearly identical to the '
+                'real-time forecast system run at MET Norway. It uses a recent version of the '
+                'Hybrid Coordinate Ocean Model (HYCOM) developed at University of Miami (Bleck '
+                '2002). HYCOM is coupled to a sea ice model; ice thermodynamics are described in '
+                'Drange and Simonsen (1996) and the elastic-viscous-plastic rheology in Hunke and '
+                'Dukowicz (1997).',
+            utils.SUMMARY_FIELDS['processing_level']: '4',
+            utils.SUMMARY_FIELDS['product']: 'ARCTIC_MULTIYEAR_PHY_002_003'
+        })
+
+    def get_platform(self, raw_metadata):
+        return utils.get_gcmd_platform('OPERATIONAL MODELS')
+
+    def get_instrument(self, raw_metadata):
+        return utils.get_gcmd_instrument('Computer')
+
+    def get_location_geometry(self, raw_metadata):
+        return 'POLYGON((-180 53, -180 90, 180 90, 180 53, -180 53))'
+
+    @utils.raises(KeyError)
+    def get_dataset_parameters(self, raw_metadata):
+        return utils.create_parameter_list([
+            'latitude',
+            'longitude',
+            'sea_water_potential_temperature_at_sea_floor',
+            'ocean_mixed_layer_thickness_defined_by_sigma_theta',
+            'sea_floor_depth_below_geoid',
+            'sea_ice_area_fraction',
+            'surface_snow_thickness',
+            'sea_ice_thickness',
+            'sea_water_salinity',
+            'ocean_barotropic_streamfunction',
+            'sea_water_potential_temperature',
+            'sea_water_x_velocity',
+            'sea_water_y_velocity',
+            'sea_ice_x_velocity',
+            'sea_ice_y_velocity',
+            'sea_surface_height_above_geoid',
+        ])
+
+
 class CMEMS002001aMetadataNormalizer(CMEMSMetadataNormalizer):
     """Normalizer for the ARCTIC_ANALYSIS_FORECAST_PHYS_002_001_a product"""
 
@@ -627,3 +700,4 @@ class CMEMS002004MetadataNormalizer(CMEMSMetadataNormalizer):
             if prefix in raw_metadata['url']:
                 return utils.create_parameter_list(parameter_list)
         return []
+

--- a/metanorm/normalizers/geospaas/cmems.py
+++ b/metanorm/normalizers/geospaas/cmems.py
@@ -532,3 +532,98 @@ class CMEMS002001MetadataNormalizer(CMEMSMetadataNormalizer):
                 return utils.create_parameter_list(parameter_list)
         return []
 
+
+class CMEMS002004MetadataNormalizer(CMEMSMetadataNormalizer):
+    """Normalizer for the ARCTIC_ANALYSISFORECAST_BGC_002_004 product"""
+    url_prefix = None
+    time_patterns = (
+        (
+            re.compile(rf"/{utils.YEARMONTHDAY_REGEX}_dm-metno-MODEL-topaz5_ecosmo-ARC-.*\.nc"),
+            utils.create_datetime,
+            lambda time: (time, time + relativedelta(days=1))
+        ),
+        (
+            re.compile(rf"/{utils.YEARMONTH_REGEX}_mm-metno-MODEL-topaz5_ecosmo-ARC-.*\.nc"),
+            utils.create_datetime,
+            lambda time: (time, time + relativedelta(months=1))
+        ),
+    )
+
+    def check(self, raw_metadata):
+        return '-metno-MODEL-topaz5_ecosmo-ARC-' in self.get_entry_id(raw_metadata)
+
+    def get_provider(self, raw_metadata):
+        if 'thredds.met.no' in raw_metadata['url']:
+            return utils.get_gcmd_provider(['NO/MET'])
+        elif 'cmems' in raw_metadata['url']:
+            return utils.get_gcmd_provider(['CMEMS'])
+        else:
+            return None
+
+    def get_entry_title(self, raw_metadata):
+        return 'Arctic Ocean Biogeochemistry Analysis and Forecast, 6.25 km'
+
+    def get_summary(self, raw_metadata):
+        return utils.dict_to_string({
+            utils.SUMMARY_FIELDS['description']: 'TOPAZ 5 biochemistry model',
+            utils.SUMMARY_FIELDS['processing_level']: '4',
+            utils.SUMMARY_FIELDS['product']: 'ARCTIC_ANALYSISFORECAST_BGC_002_004'
+        })
+
+    def get_platform(self, raw_metadata):
+        return utils.get_gcmd_platform('OPERATIONAL MODELS')
+
+    def get_instrument(self, raw_metadata):
+        return utils.get_gcmd_instrument('Computer')
+
+    def get_location_geometry(self, raw_metadata):
+        return 'POLYGON((-180 50, -180 90, 180 90, 180 50, -180 50))'
+
+    @utils.raises(KeyError)
+    def get_dataset_parameters(self, raw_metadata):
+        parameters = {
+            "/topaz5_bgc_mm_files/": (
+                'longitude',
+                'latitude',
+                'sea_floor_depth_below_geoid',
+                ('net_primary_production_of_biomass_'
+                    'expressed_as_carbon_per_unit_volume_in_sea_water'),
+                'mass_concentration_of_chlorophyll_a_in_sea_water',
+                'volume_attenuation_coefficient_of_downwelling_radiative_flux_in_sea_water',
+                'mole_concentration_of_nitrate_in_sea_water',
+                'mole_concentration_of_phosphate_in_sea_water',
+                'mole_concentration_of_phytoplankton_expressed_as_carbon_in_sea_water',
+                'mole_concentration_of_zooplankton_expressed_as_carbon_in_sea_water',
+                'mole_concentration_of_dissolved_molecular_oxygen_in_sea_water',
+                'mole_concentration_of_silicate_in_sea_water',
+                'sinking_mole_flux_of_particulate_organic_matter_expressed_as_carbon_in_sea_water',
+                'sea_water_ph_reported_on_total_scale',
+                'mole_concentration_of_dissolved_inorganic_carbon_in_sea_water',
+                'surface_partial_pressure_of_carbon_dioxide_in_sea_water',
+            ),
+            "/topaz5_bgc_dm_files/": (
+                'longitude',
+                'latitude',
+                'depth',
+                'sea_floor_depth_below_geoid',
+                ('net_primary_production_of_biomass_'
+                    'expressed_as_carbon_per_unit_volume_in_sea_water'),
+                'mass_concentration_of_chlorophyll_a_in_sea_water',
+                'volume_attenuation_coefficient_of_downwelling_radiative_flux_in_sea_water',
+                'mole_concentration_of_nitrate_in_sea_water',
+                'mole_concentration_of_phosphate_in_sea_water',
+                'mole_concentration_of_phytoplankton_expressed_as_carbon_in_sea_water',
+                'mole_concentration_of_zooplankton_expressed_as_carbon_in_sea_water',
+                'mole_concentration_of_dissolved_molecular_oxygen_in_sea_water',
+                'mole_concentration_of_silicate_in_sea_water',
+                'sinking_mole_flux_of_particulate_organic_matter_expressed_as_carbon_in_sea_water',
+                'sea_water_ph_reported_on_total_scale',
+                'mole_concentration_of_dissolved_inorganic_carbon_in_sea_water',
+                'surface_partial_pressure_of_carbon_dioxide_in_sea_water',
+            ),
+        }
+
+        for prefix, parameter_list in parameters.items():
+            if prefix in raw_metadata['url']:
+                return utils.create_parameter_list(parameter_list)
+        return []

--- a/metanorm/normalizers/geospaas/cmems.py
+++ b/metanorm/normalizers/geospaas/cmems.py
@@ -361,3 +361,87 @@ class CMEMS005001MetadataNormalizer(CMEMSMetadataNormalizer):
             if raw_metadata['url'].startswith(f"{self.url_prefix}/{prefix}"):
                 return utils.create_parameter_list(parameter_list)
         return []
+
+
+class CMEMS002001aMetadataNormalizer(CMEMSMetadataNormalizer):
+    """Normalizer for the ARCTIC_ANALYSIS_FORECAST_PHYS_002_001_a product"""
+
+    url_prefix = 'ftp://nrt.cmems-du.eu/Core/ARCTIC_ANALYSIS_FORECAST_PHYS_002_001_a'
+    time_patterns = (
+        (
+            re.compile(rf"/{utils.YEARMONTHDAY_REGEX}_(dm|hr)-metno-MODEL-topaz4-ARC-.*\.nc"),
+            utils.create_datetime,
+            lambda time: (time, time + relativedelta(days=1))
+        ),
+    )
+
+    def get_entry_title(self, raw_metadata):
+        return 'Arctic Ocean Physics Analysis and Forecast'
+
+    def get_summary(self, raw_metadata):
+        return utils.dict_to_string({
+            utils.SUMMARY_FIELDS['description']:
+                'The operational TOPAZ4 Arctic Ocean system uses the HYCOM model and a 100-member '
+                'EnKF assimilation scheme. It is run daily to provide 10 days of forecast(average '
+                'of 10 members) of the 3D physical ocean, including sea ice data assimilation is '
+                'performed weekly to provide 7 days of analysis(ensemble average). Output products '
+                'are interpolated on a grid of 12.5 km resolution at the North Pole (equivalent to '
+                '1/8 deg in mid-latitudes) on a polar stereographic projection.',
+            utils.SUMMARY_FIELDS['processing_level']: '4',
+            utils.SUMMARY_FIELDS['product']: 'ARCTIC_ANALYSIS_FORECAST_PHYS_002_001_a'
+        })
+
+    def get_platform(self, raw_metadata):
+        return utils.get_gcmd_platform('OPERATIONAL MODELS')
+
+    def get_instrument(self, raw_metadata):
+        return utils.get_gcmd_instrument('Computer')
+
+    def get_location_geometry(self, raw_metadata):
+        return 'POLYGON((-180 62, -180 90, 180 90, 180 62, -180 62))'
+
+    @utils.raises(KeyError)
+    def get_dataset_parameters(self, raw_metadata):
+        parameters = {
+            "dataset-topaz4-arc-1hr-myoceanv2-be/": (
+                'longitude',
+                'latitude',
+                'sea_floor_depth_below_geoid',
+                'sea_water_salinity',
+                'sea_water_potential_temperature',
+                'sea_ice_area_fraction',
+                'sea_ice_thickness',
+                'surface_snow_thickness',
+                'sea_ice_x_velocity',
+                'sea_ice_y_velocity',
+                'sea_surface_height_above_geoid',
+                'x_sea_water_velocity',
+                'y_sea_water_velocity',
+            ),
+            "dataset-topaz4-arc-myoceanv2-be/": (
+                'longitude',
+                'latitude',
+                'sea_floor_depth_below_geoid',
+                'sea_water_potential_temperature',
+                'sea_water_salinity',
+                'x_sea_water_velocity',
+                'y_sea_water_velocity',
+                'ocean_mixed_layer_thickness',
+                'sea_surface_height_above_geoid',
+                'ocean_barotropic_streamfunction',
+                'sea_ice_area_fraction',
+                'sea_ice_thickness',
+                'sea_ice_x_velocity',
+                'sea_ice_y_velocity',
+                'surface_snow_thickness',
+                'fy_frac',
+                'fy_age',
+                'sea_ice_albedo',
+                'sea_water_potential_temperature_at_sea_floor',
+            ),
+        }
+
+        for prefix, parameter_list in parameters.items():
+            if raw_metadata['url'].startswith(f"{self.url_prefix}/{prefix}"):
+                return utils.create_parameter_list(parameter_list)
+        return []

--- a/metanorm/normalizers/geospaas/cmems.py
+++ b/metanorm/normalizers/geospaas/cmems.py
@@ -700,4 +700,3 @@ class CMEMS002004MetadataNormalizer(CMEMSMetadataNormalizer):
             if prefix in raw_metadata['url']:
                 return utils.create_parameter_list(parameter_list)
         return []
-

--- a/metanorm/normalizers/geospaas/cmems.py
+++ b/metanorm/normalizers/geospaas/cmems.py
@@ -445,3 +445,90 @@ class CMEMS002001aMetadataNormalizer(CMEMSMetadataNormalizer):
             if raw_metadata['url'].startswith(f"{self.url_prefix}/{prefix}"):
                 return utils.create_parameter_list(parameter_list)
         return []
+
+
+class CMEMS002001MetadataNormalizer(CMEMSMetadataNormalizer):
+    """Normalizer for the ARCTIC_ANALYSISFORECAST_PHY_002_001 product"""
+    # for now the product is only available at met.no,
+    # so we use the file name for identification rather than the URL
+    url_prefix = None
+    time_patterns = (
+        (
+            re.compile(rf"/{utils.YEARMONTHDAY_REGEX}_(dm|hr)-metno-MODEL-topaz5-ARC-.*\.nc"),
+            utils.create_datetime,
+            lambda time: (time, time + relativedelta(days=1))
+        ),
+    )
+
+    def check(self, raw_metadata):
+        return '-metno-MODEL-topaz5-ARC-' in self.get_entry_id(raw_metadata)
+
+    def get_provider(self, raw_metadata):
+        return utils.get_gcmd_provider(['NO/MET'])
+
+    def get_entry_title(self, raw_metadata):
+        return 'Arctic Ocean Physics Analysis and Forecast, 6.25 km'
+
+    def get_summary(self, raw_metadata):
+        return utils.dict_to_string({
+            utils.SUMMARY_FIELDS['description']: 'TOPAZ 5 physical model',
+            utils.SUMMARY_FIELDS['processing_level']: '4',
+            utils.SUMMARY_FIELDS['product']: 'ARCTIC_ANALYSISFORECAST_PHY_002_001'
+        })
+
+    def get_platform(self, raw_metadata):
+        return utils.get_gcmd_platform('OPERATIONAL MODELS')
+
+    def get_instrument(self, raw_metadata):
+        return utils.get_gcmd_instrument('Computer')
+
+    def get_location_geometry(self, raw_metadata):
+        return 'POLYGON((-180 50, -180 90, 180 90, 180 50, -180 50))'
+
+    @utils.raises(KeyError)
+    def get_dataset_parameters(self, raw_metadata):
+        parameters = {
+            "/topaz5_phy_hr_files/": (
+                'longitude',
+                'latitude',
+                'sea_floor_depth_below_geoid',
+                'sea_water_salinity',
+                'sea_water_potential_temperature',
+                'sea_ice_area_fraction',
+                'sea_ice_thickness',
+                'surface_snow_thickness',
+                'sea_ice_x_velocity',
+                'sea_ice_y_velocity',
+                'sea_surface_height_above_geoid',
+                'sea_water_x_velocity',
+                'sea_water_y_velocity',
+            ),
+            "/topaz5_phy_dm_files/": (
+                'longitude',
+                'latitude',
+                'depth',
+                'sea_floor_depth_below_geoid',
+                'sea_water_potential_temperature',
+                'sea_water_salinity',
+                'sea_water_x_velocity',
+                'sea_water_y_velocity',
+                'ocean_mixed_layer_thickness_defined_by_sigma_theta',
+                'sea_surface_height_above_geoid',
+                'ocean_barotropic_streamfunction',
+                'sea_ice_area_fraction',
+                'sea_ice_thickness',
+                'sea_ice_x_velocity',
+                'sea_ice_y_velocity',
+                'surface_snow_thickness',
+                'age_of_sea_ice',
+                'sea_ice_classification',
+                'sea_ice_albedo',
+                'sea_water_potential_temperature_at_sea_floor',
+            ),
+        }
+
+        for prefix, parameter_list in parameters.items():
+            if prefix in raw_metadata['url']:
+                return utils.create_parameter_list(parameter_list)
+        return []
+

--- a/metanorm/normalizers/geospaas/cmems.py
+++ b/metanorm/normalizers/geospaas/cmems.py
@@ -414,7 +414,6 @@ class CMEMS002003MetadataNormalizer(CMEMSMetadataNormalizer):
     def get_location_geometry(self, raw_metadata):
         return 'POLYGON((-180 53, -180 90, 180 90, 180 53, -180 53))'
 
-    @utils.raises(KeyError)
     def get_dataset_parameters(self, raw_metadata):
         return utils.create_parameter_list([
             'latitude',
@@ -700,3 +699,121 @@ class CMEMS002004MetadataNormalizer(CMEMSMetadataNormalizer):
             if prefix in raw_metadata['url']:
                 return utils.create_parameter_list(parameter_list)
         return []
+
+
+class CMEMS001027MetadataNormalizer(CMEMSMetadataNormalizer):
+    """Normalizer for the GLOBAL_ANALYSISFORECAST_WAV_001_027 product
+    """
+
+    url_prefix = 'ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSISFORECAST_WAV_001_027'
+    time_patterns = (
+        (
+            re.compile(r'/mfwamglocep_' + utils.YEARMONTHDAY_REGEX + r'00_R[0-9]{8}.*\.nc$'),
+            utils.create_datetime,
+            lambda time: (time, time + relativedelta(hours=24))
+        ),
+    )
+
+    def get_entry_title(self, raw_metadata):
+        return 'Global Ocean Waves Analysis and Forecast'
+
+    def get_summary(self, raw_metadata):
+        return utils.dict_to_string({
+            utils.SUMMARY_FIELDS['description']:
+            'The operational global ocean analysis and forecast system of Météo-France with a '
+            'resolution of 1/12 degree is providing daily analyses and 10 days forecasts for the '
+            'global ocean sea surface waves. This product includes 3-hourly instantaneous fields of'
+            ' integrated wave parameters from the total spectrum (significant height, period, '
+            'direction, Stokes drift,...etc), as well as the following partitions: the wind wave, '
+            'the primary and secondary swell waves.',
+            utils.SUMMARY_FIELDS['processing_level']: '4',
+            utils.SUMMARY_FIELDS['product']: 'GLOBAL_ANALYSISFORECAST_WAV_001_027'
+        })
+
+    def get_platform(self, raw_metadata):
+        return utils.get_gcmd_platform('OPERATIONAL MODELS')
+
+    def get_instrument(self, raw_metadata):
+        return utils.get_gcmd_instrument('Computer')
+
+    def get_location_geometry(self, raw_metadata):
+        return utils.WORLD_WIDE_COVERAGE_WKT
+
+    def get_dataset_parameters(self, raw_metadata):
+        return utils.create_parameter_list((
+            'sea_surface_wave_significant_height',
+            'sea_surface_wind_wave_from_direction',
+            'sea_surface_wind_wave_significant_height',
+            'sea_surface_primary_swell_wave_from_direction',
+            'sea_surface_primary_swell_wave_mean_period',
+            'sea_surface_secondary_swell_wave_from_direction',
+            'sea_surface_secondary_swell_wave_mean_period',
+            'sea_surface_wave_from_direction',
+            'sea_surface_wave_mean_period_from_variance_spectral_density_inverse_frequency_moment',
+            'sea_surface_primary_swell_wave_significant_height',
+            'sea_surface_secondary_swell_wave_significant_height',
+            'sea_surface_wave_period_at_variance_spectral_density_maximum',
+            'sea_surface_wave_stokes_drift_x_velocity',
+            'sea_surface_wave_stokes_drift_y_velocity',
+            'sea_surface_wave_from_direction_at_variance_spectral_density_maximum',
+            'sea_surface_wave_mean_period_from_variance_spectral_density_second_frequency_moment',
+            'sea_surface_wind_wave_mean_period',
+        ))
+
+
+class CMEMS001028MetadataNormalizer(CMEMSMetadataNormalizer):
+    """Normalizer for the GLOBAL_ANALYSIS_FORECAST_BIO_001_028 product
+    """
+
+    url_prefix = 'ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_BIO_001_028'
+    time_patterns = (
+        (
+            re.compile(r'/mercatorbiomer4v2r1_global_mean_' + utils.YEARMONTHDAY_REGEX + '.nc$'),
+            utils.create_datetime,
+            lambda time: (time, time + relativedelta(hours=24))
+        ),
+        (
+            re.compile(r'/mercatorbiomer4v2r1_global_mean_' + utils.YEARMONTH_REGEX + '.nc$'),
+            utils.create_datetime,
+            lambda time: (time, time + relativedelta(months=1))
+        ),
+    )
+
+    def get_entry_title(self, raw_metadata):
+        return 'Global Ocean Biogeochemistry Analysis and Forecast'
+
+    def get_summary(self, raw_metadata):
+        return utils.dict_to_string({
+            utils.SUMMARY_FIELDS['description']:
+            'The Operational Mercator Ocean biogeochemical global ocean analysis and forecast '
+            'system at 1/4 degree is providing 10 days of 3D global ocean forecasts updated weekly.'
+            ' The time series is aggregated in time, in order to reach a two full year’s time '
+            'series sliding window.',
+            utils.SUMMARY_FIELDS['processing_level']: '4',
+            utils.SUMMARY_FIELDS['product']: 'GLOBAL_ANALYSIS_FORECAST_BIO_001_028'
+        })
+
+    def get_platform(self, raw_metadata):
+        return utils.get_gcmd_platform('OPERATIONAL MODELS')
+
+    def get_instrument(self, raw_metadata):
+        return utils.get_gcmd_instrument('Computer')
+
+    def get_location_geometry(self, raw_metadata):
+        return utils.WORLD_WIDE_COVERAGE_WKT
+
+    def get_dataset_parameters(self, raw_metadata):
+        return utils.create_parameter_list((
+            'sea_water_alkalinity_expressed_as_mole_equivalent',
+            'mass_concentration_of_chlorophyll_a_in_sea_water',
+            'mole_concentration_of_dissolved_inorganic_carbon_in_sea_water',
+            'mole_concentration_of_dissolved_iron_in_sea_water',
+            'mole_concentration_of_nitrate_in_sea_water',
+            'net_primary_production_of_biomass_expressed_as_carbon_per_unit_volume_in_sea_water',
+            'mole_concentration_of_dissolved_molecular_oxygen_in_sea_water',
+            'sea_water_ph_reported_on_total_scale',
+            'mole_concentration_of_phytoplankton_expressed_as_carbon_in_sea_water',
+            'mole_concentration_of_phosphate_in_sea_water',
+            'mole_concentration_of_silicate_in_sea_water',
+            'surface_partial_pressure_of_carbon_dioxide_in_sea_water',
+        ))

--- a/metanorm/normalizers/geospaas/cmems.py
+++ b/metanorm/normalizers/geospaas/cmems.py
@@ -534,7 +534,7 @@ class CMEMS002001MetadataNormalizer(CMEMSMetadataNormalizer):
     )
 
     def check(self, raw_metadata):
-        return '-metno-MODEL-topaz5-ARC-' in self.get_entry_id(raw_metadata)
+        return '-metno-MODEL-topaz5-ARC-' in raw_metadata.get('url', '')
 
     def get_provider(self, raw_metadata):
         return utils.get_gcmd_provider(['NO/MET'])
@@ -623,7 +623,7 @@ class CMEMS002004MetadataNormalizer(CMEMSMetadataNormalizer):
     )
 
     def check(self, raw_metadata):
-        return '-metno-MODEL-topaz5_ecosmo-ARC-' in self.get_entry_id(raw_metadata)
+        return '-metno-MODEL-topaz5_ecosmo-ARC-' in raw_metadata.get('url', '')
 
     def get_provider(self, raw_metadata):
         if 'thredds.met.no' in raw_metadata['url']:

--- a/metanorm/normalizers/geospaas/cmems_in_situ_tac.py
+++ b/metanorm/normalizers/geospaas/cmems_in_situ_tac.py
@@ -80,10 +80,10 @@ class CMEMSInSituTACMetadataNormalizer(GeoSPaaSMetadataNormalizer):
         return dateutil.parser.parse(raw_metadata['time_coverage_end'])
 
     def get_platform(self, raw_metadata):
-        return pti.get_gcmd_platform('In Situ Ocean-based Platforms')
+        return utils.get_gcmd_platform('In Situ Ocean-based Platforms')
 
     def get_instrument(self, raw_metadata):
-        return pti.get_gcmd_instrument('In Situ/Laboratory Instruments')
+        return utils.get_gcmd_instrument('In Situ/Laboratory Instruments')
 
     @utils.raises(KeyError)
     def get_location_geometry(self, raw_metadata):

--- a/metanorm/normalizers/geospaas/cpom.py
+++ b/metanorm/normalizers/geospaas/cpom.py
@@ -39,7 +39,7 @@ class CPOMAltimetryMetadataNormalizer(GeoSPaaSMetadataNormalizer):
         return raw_metadata.get('geometry', '')
 
     def get_provider(self, raw_metadata):
-        return pti.get_gcmd_provider('UC-LONDON/CPOM')
+        return utils.get_gcmd_provider(['UC-LONDON/CPOM'])
 
     def get_dataset_parameters(self, raw_metadata):
-        return [pti.get_wkv_variable('sea_surface_height_above_sea_level')]
+        return utils.create_parameter_list(['sea_surface_height_above_sea_level'])

--- a/metanorm/normalizers/geospaas/nextsim.py
+++ b/metanorm/normalizers/geospaas/nextsim.py
@@ -61,10 +61,10 @@ class NextsimMetadataNormalizer(GeoSPaaSMetadataNormalizer):
         return self.get_time_coverage_start(raw_metadata) + timedelta(days=1)
 
     def get_platform(self, raw_metadata):
-        return pti.get_gcmd_platform('OPERATIONAL MODELS')
+        return utils.get_gcmd_platform('OPERATIONAL MODELS')
 
     def get_instrument(self, raw_metadata):
-        return pti.get_gcmd_instrument('Computer')
+        return utils.get_gcmd_instrument('Computer')
 
     def get_location_geometry(self, raw_metadata):
         return utils.wkt_polygon_from_wgs84_limits('90', '62', '180', '-180')

--- a/metanorm/normalizers/geospaas/osisaf.py
+++ b/metanorm/normalizers/geospaas/osisaf.py
@@ -3,7 +3,6 @@
 import re
 
 import dateutil.parser
-import pythesint as pti
 from dateutil.tz import tzutc
 
 import metanorm.utils as utils
@@ -60,12 +59,12 @@ class OSISAFMetadataNormalizer(GeoSPaaSMetadataNormalizer):
             if ('_ice_conc' in raw_metadata['product_name']
                     or '_ice_type' in raw_metadata['product_name']
                     or '_ice_edge' in raw_metadata['product_name']):
-                return pti.get_gcmd_instrument('Imaging Spectrometers/Radiometers')
+                return utils.get_gcmd_instrument('Imaging Spectrometers/Radiometers')
             elif 'amsr2ice_conc' in raw_metadata['product_name']:
-                return pti.get_gcmd_instrument('AMSR2')
+                return utils.get_gcmd_instrument('AMSR2')
             elif '_mr_ice_drift' in raw_metadata['product_name']:
-                return pti.get_gcmd_instrument('AVHRR')
-        return pti.get_gcmd_instrument('Earth Remote Sensing Instruments')
+                return utils.get_gcmd_instrument('AVHRR')
+        return utils.get_gcmd_instrument('Earth Remote Sensing Instruments')
 
     @utils.raises(KeyError)
     def get_location_geometry(self, raw_metadata):

--- a/metanorm/normalizers/geospaas/radarsat2_csv.py
+++ b/metanorm/normalizers/geospaas/radarsat2_csv.py
@@ -36,10 +36,10 @@ class Radarsat2CSVMetadataNormalizer(GeoSPaaSMetadataNormalizer):
         return self.get_time_coverage_start(raw_metadata) + timedelta(minutes=5)
 
     def get_platform(self, raw_metadata):
-        return pti.get_gcmd_platform('RADARSAT-2')
+        return utils.get_gcmd_platform('RADARSAT-2')
 
     def get_instrument(self, raw_metadata):
-        return pti.get_gcmd_instrument('C-SAR')
+        return utils.get_gcmd_instrument('C-SAR')
 
     @utils.raises(KeyError)
     def get_location_geometry(self, raw_metadata):
@@ -50,7 +50,7 @@ class Radarsat2CSVMetadataNormalizer(GeoSPaaSMetadataNormalizer):
                 f"{footprint[8]} {footprint[9]}))")
 
     def get_provider(self, raw_metadata):
-        return pti.get_gcmd_provider('CSA')
+        return utils.get_gcmd_provider(['CSA'])
 
     def get_dataset_parameters(self, raw_metadata):
-        return [pti.get_wkv_variable('surface_backwards_scattering_coefficient_of_radar_wave')]
+        return utils.create_parameter_list('surface_backwards_scattering_coefficient_of_radar_wave')

--- a/metanorm/normalizers/geospaas/scihub_odata.py
+++ b/metanorm/normalizers/geospaas/scihub_odata.py
@@ -103,7 +103,6 @@ class ScihubODataMetadataNormalizer(GeoSPaaSMetadataNormalizer):
         """Returns a WKT string corresponding to the location of the dataset"""
         return raw_metadata['JTS footprint']
 
-    @utils.raises(KeyError)
     def get_provider(self, raw_metadata):
         """Returns a GCMD-like provider data structure"""
         return utils.get_gcmd_provider(['ESA/EO'])
@@ -112,8 +111,8 @@ class ScihubODataMetadataNormalizer(GeoSPaaSMetadataNormalizer):
     def get_dataset_parameters(self, raw_metadata):
         """Returns known dataset parameters depending on the dataset's ID"""
         if self.SENTINEL1_ID_MATCHER.match(raw_metadata['Identifier']):
-            return [
-                utils.get_cf_or_wkv_standard_name(
-                    'surface_backwards_scattering_coefficient_of_radar_wave')]
+            return utils.create_parameter_list([
+                'surface_backwards_scattering_coefficient_of_radar_wave'
+            ])
         else:
             return []

--- a/metanorm/utils.py
+++ b/metanorm/utils.py
@@ -301,7 +301,7 @@ def translate_west_coordinates(multipolygon):
         return shapely.geometry.LinearRing(translate_point(point) for point in ring.coords)
 
     new_polygons = []
-    for polygon in multipolygon:
+    for polygon in multipolygon.geoms:
 
         exterior_ring = translate_ring(polygon.exterior)
 
@@ -335,7 +335,7 @@ def restore_west_coordinates(multipolygon):
         return shapely.geometry.LinearRing(restore_point(point, is_east) for point in ring.coords)
 
     new_polygons = []
-    for polygon in multipolygon:
+    for polygon in multipolygon.geoms:
         # Determine if this polygon is on the east or west side of the
         # IDL. It has been split already, so it is either east or west.
         # We find the first point which is not on the IDL and check

--- a/tests/normalizers/test_aviso.py
+++ b/tests/normalizers/test_aviso.py
@@ -2,7 +2,6 @@
 
 import unittest
 import unittest.mock as mock
-from collections import OrderedDict
 from datetime import datetime, timezone
 
 import metanorm.normalizers as normalizers
@@ -134,29 +133,26 @@ class AVISOAltimetryMetadataNormalizerTests(unittest.TestCase):
         with self.assertRaises(MetadataNormalizationError):
             self.normalizer.get_time_coverage_end({})
 
-    def test_get_platform(self):
+    def test_gcmd_platform(self):
         """Test getting the platform"""
-        self.assertDictEqual(
-            self.normalizer.get_platform({}),
-            OrderedDict([
-                ('Category', 'Earth Observation Satellites'),
-                ('Series_Entity', ''),
-                ('Short_Name', ''),
-                ('Long_Name', '')])
-        )
+        with mock.patch('metanorm.utils.get_gcmd_platform') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_platform({}),
+                mock_get_gcmd_method.return_value)
 
-    def test_get_instrument(self):
+    def test_gcmd_instrument(self):
         """Test getting the instrument"""
-        self.assertDictEqual(
-            self.normalizer.get_instrument({}),
-            OrderedDict([
-                ('Category', 'Earth Remote Sensing Instruments'),
-                ('Class', 'Active Remote Sensing'),
-                ('Type', 'Altimeters'),
-                ('Subtype', ''),
-                ('Short_Name', ''),
-                ('Long_Name', '')])
-        )
+        with mock.patch('metanorm.utils.get_gcmd_instrument') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_instrument({}),
+                mock_get_gcmd_method.return_value)
+
+    def test_gcmd_provider(self):
+        """Test getting the provider"""
+        with mock.patch('metanorm.utils.get_gcmd_provider') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_provider({}),
+                mock_get_gcmd_method.return_value)
 
     def test_get_location_geometry(self):
         """Test getting the geometry"""
@@ -168,17 +164,3 @@ class AVISOAltimetryMetadataNormalizerTests(unittest.TestCase):
         """
         self.assertEqual(self.normalizer.get_location_geometry({}), '')
 
-    def test_get_provider(self):
-        """Test getting the provider"""
-        self.assertDictEqual(
-            self.normalizer.get_provider({}),
-            OrderedDict([
-                ('Bucket_Level0', 'COMMERCIAL'),
-                ('Bucket_Level1', ''),
-                ('Bucket_Level2', ''),
-                ('Bucket_Level3', ''),
-                ('Short_Name', 'AVISO'),
-                ('Long_Name',
-                'Archiving, Validation and Interpretation of Satellite Oceanographic Data'),
-                ('Data_Center_URL', 'http://www.aviso.oceanobs.com/')])
-        )

--- a/tests/normalizers/test_ceda_esa_cci.py
+++ b/tests/normalizers/test_ceda_esa_cci.py
@@ -1,11 +1,10 @@
 """Tests for the ESA CCI normalizer"""
 import unittest
-from collections import OrderedDict
+import unittest.mock as mock
 from datetime import datetime
 from dateutil.tz import tzutc
 
 import metanorm.normalizers as normalizers
-from .data import DATASET_PARAMETERS
 from metanorm.errors import MetadataNormalizationError
 
 
@@ -82,25 +81,26 @@ class CEDAESACCIMetadataNormalizerTestCase(unittest.TestCase):
         with self.assertRaises(MetadataNormalizationError):
             self.normalizer.get_time_coverage_end({})
 
-    def test_platform(self):
-        """platform from CEDAESACCIMetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_platform({}),
-            OrderedDict([('Category', 'Earth Observation Satellites'),
-                         ('Series_Entity', ''),
-                         ('Short_Name', ''),
-                         ('Long_Name', '')]))
+    def test_gcmd_platform(self):
+        """Test getting the platform"""
+        with mock.patch('metanorm.utils.get_gcmd_platform') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_platform({}),
+                mock_get_gcmd_method.return_value)
 
-    def test_instrument(self):
-        """instrument from CEDAESACCIMetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_instrument({}),
-            OrderedDict([('Category', 'Earth Remote Sensing Instruments'),
-                         ('Class', 'Passive Remote Sensing'),
-                         ('Type', 'Spectrometers/Radiometers'),
-                         ('Subtype', 'Imaging Spectrometers/Radiometers'),
-                         ('Short_Name', ''),
-                         ('Long_Name', '')]))
+    def test_gcmd_instrument(self):
+        """Test getting the instrument"""
+        with mock.patch('metanorm.utils.get_gcmd_instrument') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_instrument({}),
+                mock_get_gcmd_method.return_value)
+
+    def test_gcmd_provider(self):
+        """Test getting the provider"""
+        with mock.patch('metanorm.utils.get_gcmd_provider') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_provider({}),
+                mock_get_gcmd_method.return_value)
 
     def test_location_geometry(self):
         """geometry from CEDAESACCIMetadataNormalizer """
@@ -108,20 +108,9 @@ class CEDAESACCIMetadataNormalizerTestCase(unittest.TestCase):
             self.normalizer.get_location_geometry({}),
             'POLYGON((-180 -90, -180 90, 180 90, 180 -90, -180 -90))')
 
-    def test_provider(self):
-        """provider from CEDAESACCIMetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_provider({}),
-            OrderedDict([('Bucket_Level0', 'MULTINATIONAL ORGANIZATIONS'),
-                         ('Bucket_Level1', ''),
-                         ('Bucket_Level2', ''),
-                         ('Bucket_Level3', ''),
-                         ('Short_Name', 'ESA/CCI'),
-                         ('Long_Name', 'Climate Change Initiative, European Space Agency'),
-                         ('Data_Center_URL', '')]))
-
     def test_dataset_parameters(self):
         """dataset_parameters from CEDAESACCIMetadataNormalizer """
-        self.assertEqual(self.normalizer.get_dataset_parameters({}), [
-            DATASET_PARAMETERS['sea_surface_temperature'],
-        ])
+        with mock.patch('metanorm.utils.create_parameter_list') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_dataset_parameters({}),
+                mock_get_gcmd_method.return_value)

--- a/tests/normalizers/test_cmems.py
+++ b/tests/normalizers/test_cmems.py
@@ -3,12 +3,36 @@
 
 import unittest
 import unittest.mock as mock
-from collections import OrderedDict
 from datetime import datetime, timezone
 
 import metanorm.normalizers as normalizers
-from .data import DATASET_PARAMETERS
 from metanorm.errors import MetadataNormalizationError
+
+
+class GCMDTestsMixin():
+    """Mixin used to easily add test methods for GCMD searches
+    """
+
+    def test_gcmd_platform(self):
+        """Test getting the platform"""
+        with mock.patch('metanorm.utils.get_gcmd_platform') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_platform(mock.MagicMock()),
+                mock_get_gcmd_method.return_value)
+
+    def test_gcmd_instrument(self):
+        """Test getting the instrument"""
+        with mock.patch('metanorm.utils.get_gcmd_instrument') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_instrument(mock.MagicMock()),
+                mock_get_gcmd_method.return_value)
+
+    def test_dataset_parameters(self):
+        """Test getting the dataset parameters"""
+        with mock.patch('metanorm.utils.create_parameter_list') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_dataset_parameters(mock.MagicMock()),
+                mock_get_gcmd_method.return_value)
 
 
 class CMEMSMetadataNormalizerTestCase(unittest.TestCase):
@@ -43,17 +67,12 @@ class CMEMSMetadataNormalizerTestCase(unittest.TestCase):
         with self.assertRaises(MetadataNormalizationError):
             self.normalizer.get_entry_id({})
 
-    def test_provider(self):
-        """The provider is always CMEMS"""
-        self.assertEqual(
-            self.normalizer.get_provider({}),
-            OrderedDict([('Bucket_Level0', 'MULTINATIONAL ORGANIZATIONS'),
-                         ('Bucket_Level1', ''),
-                         ('Bucket_Level2', ''),
-                         ('Bucket_Level3', ''),
-                         ('Short_Name', 'CMEMS'),
-                         ('Long_Name', 'Copernicus - Marine Environment Monitoring Service'),
-                         ('Data_Center_URL', '')]))
+    def test_gcmd_provider(self):
+        """Test getting the provider"""
+        with mock.patch('metanorm.utils.get_gcmd_provider') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_provider({}),
+                mock_get_gcmd_method.return_value)
 
     def test_time_coverage(self):
         """Test that the time coverage is extracted using
@@ -83,7 +102,7 @@ class CMEMSMetadataNormalizerTestCase(unittest.TestCase):
             self.normalizer.get_time_coverage_end({})
 
 
-class CMEMS008046MetadataNormalizerTestCase(unittest.TestCase):
+class CMEMS008046MetadataNormalizerTestCase(GCMDTestsMixin, unittest.TestCase):
     """Tests for the CMEMS008046MetadataNormalizer class"""
 
     def setUp(self):
@@ -132,49 +151,14 @@ class CMEMS008046MetadataNormalizerTestCase(unittest.TestCase):
                        'nrt_global_allsat_phy_l4_20190403_20200320.nc'}),
             datetime(year=2019, month=4, day=3, hour=12, minute=0, second=0, tzinfo=timezone.utc))
 
-    def test_platform(self):
-        """platform from CMEMS008046MetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_platform({}),
-            OrderedDict([('Category', 'Earth Observation Satellites'),
-                        ('Series_Entity', ''),
-                        ('Short_Name', ''),
-                        ('Long_Name', '')]))
-
-    def test_instrument(self):
-        """instrument from CMEMS008046MetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_instrument({}),
-            OrderedDict([('Category', 'Earth Remote Sensing Instruments'),
-                         ('Class', 'Active Remote Sensing'),
-                         ('Type', 'Altimeters'),
-                         ('Subtype', ''),
-                         ('Short_Name', ''),
-                         ('Long_Name', '')]))
-
     def test_location_geometry(self):
         """geometry from CMEMS008046MetadataNormalizer """
         self.assertEqual(
             self.normalizer.get_location_geometry({}),
             'POLYGON((-180 -90, -180 90, 180 90, 180 -90, -180 -90))')
 
-    def test_dataset_parameters(self):
-        """dataset_parameters from CMEMS008046MetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_dataset_parameters({}),
-            [
-                DATASET_PARAMETERS['sea_surface_height_above_geoid'],
-                DATASET_PARAMETERS['sea_surface_height_above_sea_level'],
-                DATASET_PARAMETERS['surface_geostrophic_eastward_sea_water_velocity'],
-                DATASET_PARAMETERS['surface_geostrophic_eastward_sea_water_velocity_'
-                                   'assuming_mean_sea_level_for_geoid'],
-                DATASET_PARAMETERS['surface_geostrophic_northward_sea_water_velocity'],
-                DATASET_PARAMETERS['surface_geostrophic_northward_sea_water_velocity_'
-                                        'assuming_mean_sea_level_for_geoid'],
-            ])
 
-
-class CMEMS015003MetadataNormalizerTestCase(unittest.TestCase):
+class CMEMS015003MetadataNormalizerTestCase(GCMDTestsMixin, unittest.TestCase):
     """Tests for the CMEMS015003MetadataNormalizer class"""
 
     def setUp(self):
@@ -270,43 +254,14 @@ class CMEMS015003MetadataNormalizerTestCase(unittest.TestCase):
                        'dataset-uv-nrt-hourly_20200906T0000Z_P20200918T0000.nc'}),
             datetime(year=2020, month=9, day=7, hour=0, minute=0, second=0, tzinfo=timezone.utc))
 
-    def test_platform(self):
-        """platform from CMEMS015003MetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_platform({}),
-            OrderedDict([('Category', 'Earth Observation Satellites'),
-                        ('Series_Entity', ''),
-                        ('Short_Name', ''),
-                        ('Long_Name', '')]))
-
-    def test_instrument(self):
-        """instrument from CMEMS015003MetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_instrument({}),
-            OrderedDict([('Category', 'Earth Remote Sensing Instruments'),
-                         ('Class', 'Active Remote Sensing'),
-                         ('Type', 'Altimeters'),
-                         ('Subtype', ''),
-                         ('Short_Name', ''),
-                         ('Long_Name', '')]))
-
     def test_location_geometry(self):
         """geometry from CMEMS015003MetadataNormalizer """
         self.assertEqual(
             self.normalizer.get_location_geometry({}),
             'POLYGON((-180 -90, -180 90, 180 90, 180 -90, -180 -90))')
 
-    def test_dataset_parameters(self):
-        """dataset_parameters from CMEMS015003MetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_dataset_parameters({}),
-            [
-                DATASET_PARAMETERS['eastward_sea_water_velocity'],
-                DATASET_PARAMETERS['northward_sea_water_velocity']
-            ])
 
-
-class CMEMS001024MetadataNormalizerTestCase(unittest.TestCase):
+class CMEMS001024MetadataNormalizerTestCase(GCMDTestsMixin, unittest.TestCase):
     """Tests for the CMEMS001024MetadataNormalizer class"""
 
     def setUp(self):
@@ -482,52 +437,14 @@ class CMEMS001024MetadataNormalizerTestCase(unittest.TestCase):
                        'mercatorpsy4v3r1_gl12_mean_201807.nc'}),
             datetime(year=2018, month=8, day=1, hour=0, minute=0, second=0, tzinfo=timezone.utc))
 
-    def test_platform(self):
-        """platform from CMEMS001024MetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_platform({}),
-            OrderedDict([('Category', 'Models/Analyses'),
-                         ('Series_Entity', ''),
-                         ('Short_Name', 'OPERATIONAL MODELS'),
-                         ('Long_Name', '')]))
-
-    def test_instrument(self):
-        """instrument from CMEMS001024MetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_instrument({}),
-            OrderedDict([('Category', 'In Situ/Laboratory Instruments'),
-                         ('Class', 'Data Analysis'),
-                         ('Type', 'Environmental Modeling'),
-                         ('Subtype', ''),
-                         ('Short_Name', 'Computer'),
-                         ('Long_Name', 'Computer')]))
-
     def test_location_geometry(self):
         """geometry from CMEMS001024MetadataNormalizer """
         self.assertEqual(
             self.normalizer.get_location_geometry({}),
             'POLYGON((-180 -90, -180 90, 180 90, 180 -90, -180 -90))')
 
-    def test_dataset_parameters(self):
-        """dataset_parameters from CMEMS001024MetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_dataset_parameters({}),
-            [
-                DATASET_PARAMETERS['sea_water_potential_temperature_at_sea_floor'],
-                DATASET_PARAMETERS['ocean_mixed_layer_thickness_defined_by_sigma_theta'],
-                DATASET_PARAMETERS['sea_ice_area_fraction'],
-                DATASET_PARAMETERS['sea_ice_thickness'],
-                DATASET_PARAMETERS['sea_water_salinity'],
-                DATASET_PARAMETERS['sea_water_potential_temperature'],
-                DATASET_PARAMETERS['eastward_sea_water_velocity'],
-                DATASET_PARAMETERS['eastward_sea_ice_velocity'],
-                DATASET_PARAMETERS['northward_sea_water_velocity'],
-                DATASET_PARAMETERS['northward_sea_ice_velocity'],
-                DATASET_PARAMETERS['sea_surface_height_above_geoid']
-            ])
 
-
-class CMEMS006013MetadataNormalizerTestCase(unittest.TestCase):
+class CMEMS006013MetadataNormalizerTestCase(GCMDTestsMixin, unittest.TestCase):
     """Tests for the CMEMS006013MetadataNormalizer class"""
 
     def setUp(self):
@@ -649,26 +566,6 @@ class CMEMS006013MetadataNormalizerTestCase(unittest.TestCase):
             self.normalizer.get_time_coverage_end({'url': url}),
             datetime(year=2021, month=7, day=1, hour=0, minute=0, second=0, tzinfo=timezone.utc))
 
-    def test_platform(self):
-        """platform from CMEMS006013MetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_platform({}),
-            OrderedDict([('Category', 'Models/Analyses'),
-                         ('Series_Entity', ''),
-                         ('Short_Name', 'OPERATIONAL MODELS'),
-                         ('Long_Name', '')]))
-
-    def test_instrument(self):
-        """instrument from CMEMS006013MetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_instrument({}),
-            OrderedDict([('Category', 'In Situ/Laboratory Instruments'),
-                         ('Class', 'Data Analysis'),
-                         ('Type', 'Environmental Modeling'),
-                         ('Subtype', ''),
-                         ('Short_Name', 'Computer'),
-                         ('Long_Name', 'Computer')]))
-
     def test_location_geometry(self):
         """geometry from CMEMS006013MetadataNormalizer """
         self.assertEqual(
@@ -678,46 +575,79 @@ class CMEMS006013MetadataNormalizerTestCase(unittest.TestCase):
     def test_dataset_parameters_cur(self):
         """Should return the proper dataset parameters"""
         attributes = {
-            'url': 'ftp://nrt.cmems-du.eu/Core/MEDSEA_ANALYSISFORECAST_PHY_006_013/med-cmcc-cur'}
-        self.assertEqual(
-            self.normalizer.get_dataset_parameters(attributes), [
-                DATASET_PARAMETERS['eastward_sea_water_velocity'],
-                DATASET_PARAMETERS['northward_sea_water_velocity']
-            ])
+            'url': 'ftp://nrt.cmems-du.eu/Core/MEDSEA_ANALYSISFORECAST_PHY_006_013/med-cmcc-cur'
+        }
+        with mock.patch('metanorm.utils.create_parameter_list') as mock_utils_method:
+            self.assertEqual(
+                self.normalizer.get_dataset_parameters(attributes),
+                mock_utils_method.return_value)
+            mock_utils_method.assert_called_once_with(
+                (
+                    'eastward_sea_water_velocity',
+                    'northward_sea_water_velocity',
+                )
+            )
 
     def test_dataset_parameters_mld(self):
         """Should return the proper dataset parameters"""
         attributes = {
-            'url': 'ftp://nrt.cmems-du.eu/Core/MEDSEA_ANALYSISFORECAST_PHY_006_013/med-cmcc-mld'}
-        self.assertEqual(
-            self.normalizer.get_dataset_parameters(attributes), [
-                DATASET_PARAMETERS['ocean_mixed_layer_thickness_defined_by_sigma_theta']
-            ])
+            'url': 'ftp://nrt.cmems-du.eu/Core/MEDSEA_ANALYSISFORECAST_PHY_006_013/med-cmcc-mld'
+        }
+        with mock.patch('metanorm.utils.create_parameter_list') as mock_utils_method:
+            self.assertEqual(
+                self.normalizer.get_dataset_parameters(attributes),
+                mock_utils_method.return_value)
+            mock_utils_method.assert_called_once_with(
+                (
+                    'ocean_mixed_layer_thickness_defined_by_sigma_theta',
+                )
+            )
 
     def test_dataset_parameters_sal(self):
         """Should return the proper dataset parameters"""
         attributes = {
-            'url': 'ftp://nrt.cmems-du.eu/Core/MEDSEA_ANALYSISFORECAST_PHY_006_013/med-cmcc-sal'}
-        self.assertEqual(
-            self.normalizer.get_dataset_parameters(attributes),
-            [DATASET_PARAMETERS['sea_water_salinity']])
+            'url': 'ftp://nrt.cmems-du.eu/Core/MEDSEA_ANALYSISFORECAST_PHY_006_013/med-cmcc-sal'
+        }
+        with mock.patch('metanorm.utils.create_parameter_list') as mock_utils_method:
+            self.assertEqual(
+                self.normalizer.get_dataset_parameters(attributes),
+                mock_utils_method.return_value)
+            mock_utils_method.assert_called_once_with(
+                (
+                    'sea_water_salinity',
+                )
+            )
 
     def test_dataset_parameters_ssh(self):
         """Should return the proper dataset parameters"""
         attributes = {
-            'url': 'ftp://nrt.cmems-du.eu/Core/MEDSEA_ANALYSISFORECAST_PHY_006_013/med-cmcc-ssh'}
-        self.assertEqual(
-            self.normalizer.get_dataset_parameters(attributes),
-            [DATASET_PARAMETERS['sea_surface_height_above_geoid']])
+            'url': 'ftp://nrt.cmems-du.eu/Core/MEDSEA_ANALYSISFORECAST_PHY_006_013/med-cmcc-ssh'
+        }
+        with mock.patch('metanorm.utils.create_parameter_list') as mock_utils_method:
+            self.assertEqual(
+                self.normalizer.get_dataset_parameters(attributes),
+                mock_utils_method.return_value)
+            mock_utils_method.assert_called_once_with(
+                (
+                    'sea_surface_height_above_geoid',
+                )
+            )
 
     def test_dataset_parameters_tem(self):
         """Should return the proper dataset parameters"""
         attributes = {
-            'url': 'ftp://nrt.cmems-du.eu/Core/MEDSEA_ANALYSISFORECAST_PHY_006_013/med-cmcc-tem'}
-        self.assertEqual(self.normalizer.get_dataset_parameters(attributes), [
-            DATASET_PARAMETERS['sea_water_potential_temperature_at_sea_floor'],
-            DATASET_PARAMETERS['sea_water_potential_temperature']
-        ])
+            'url': 'ftp://nrt.cmems-du.eu/Core/MEDSEA_ANALYSISFORECAST_PHY_006_013/med-cmcc-tem'
+        }
+        with mock.patch('metanorm.utils.create_parameter_list') as mock_utils_method:
+            self.assertEqual(
+                self.normalizer.get_dataset_parameters(attributes),
+                mock_utils_method.return_value)
+            mock_utils_method.assert_called_once_with(
+                (
+                    'sea_water_potential_temperature_at_sea_floor',
+                    'sea_water_potential_temperature',
+                )
+            )
 
     def test_dataset_parameters_mask_bathy(self):
         """Should return the proper dataset parameters"""
@@ -725,11 +655,17 @@ class CMEMS006013MetadataNormalizerTestCase(unittest.TestCase):
             'url': "ftp://nrt.cmems-du.eu/Core/MEDSEA_ANALYSISFORECAST_PHY_006_013/" +
                    "MEDSEA_ANALYSISFORECAST_PHY_006_013-statics/MED-MFC_006_013_mask_bathy.nc"
         }
-        self.assertEqual(self.normalizer.get_dataset_parameters(attributes), [
-            DATASET_PARAMETERS['model_level_number_at_sea_floor'],
-            DATASET_PARAMETERS['sea_binary_mask'],
-            DATASET_PARAMETERS['sea_floor_depth_below_geoid'],
-        ])
+        with mock.patch('metanorm.utils.create_parameter_list') as mock_utils_method:
+            self.assertEqual(
+                self.normalizer.get_dataset_parameters(attributes),
+                mock_utils_method.return_value)
+            mock_utils_method.assert_called_once_with(
+                (
+                    'model_level_number_at_sea_floor',
+                    'sea_binary_mask',
+                    'sea_floor_depth_below_geoid',
+                )
+            )
 
     def test_dataset_parameters_coordinates(self):
         """Should return the proper dataset parameters"""
@@ -737,9 +673,15 @@ class CMEMS006013MetadataNormalizerTestCase(unittest.TestCase):
             'url': "ftp://nrt.cmems-du.eu/Core/MEDSEA_ANALYSISFORECAST_PHY_006_013/" +
                    "MEDSEA_ANALYSISFORECAST_PHY_006_013-statics/MED-MFC_006_013_coordinates.nc"
         }
-        self.assertEqual(
-            self.normalizer.get_dataset_parameters(attributes),
-            [DATASET_PARAMETERS['cell_thickness']])
+        with mock.patch('metanorm.utils.create_parameter_list') as mock_utils_method:
+            self.assertEqual(
+                self.normalizer.get_dataset_parameters(attributes),
+                mock_utils_method.return_value)
+            mock_utils_method.assert_called_once_with(
+                (
+                    'cell_thickness',
+                )
+            )
 
     def test_dataset_parameters_mdt(self):
         """Should return the proper dataset parameters"""
@@ -747,9 +689,15 @@ class CMEMS006013MetadataNormalizerTestCase(unittest.TestCase):
             'url': "ftp://nrt.cmems-du.eu/Core/MEDSEA_ANALYSISFORECAST_PHY_006_013/" +
                    "MEDSEA_ANALYSISFORECAST_PHY_006_013-statics/MED-MFC_006_013_mdt.nc"
         }
-        self.assertEqual(self.normalizer.get_dataset_parameters(attributes), [
-            DATASET_PARAMETERS['sea_surface_height_above_geoid'],
-        ])
+        with mock.patch('metanorm.utils.create_parameter_list') as mock_utils_method:
+            self.assertEqual(
+                self.normalizer.get_dataset_parameters(attributes),
+                mock_utils_method.return_value)
+            mock_utils_method.assert_called_once_with(
+                (
+                    'sea_surface_height_above_geoid',
+                )
+            )
 
     def test_dataset_parameters_unknown_url(self):
         """Should return an empty list if the URL starts with an
@@ -763,7 +711,7 @@ class CMEMS006013MetadataNormalizerTestCase(unittest.TestCase):
             self.normalizer.get_dataset_parameters({})
 
 
-class CMEMS005001MetadataNormalizerTestCase(unittest.TestCase):
+class CMEMS005001MetadataNormalizerTestCase(GCMDTestsMixin, unittest.TestCase):
     """Tests for the CMEMS005001MetadataNormalizer class"""
 
     def setUp(self):
@@ -896,26 +844,6 @@ class CMEMS005001MetadataNormalizerTestCase(unittest.TestCase):
             }),
             datetime(year=2019, month=11, day=1, hour=0, minute=0, second=0, tzinfo=timezone.utc))
 
-    def test_platform(self):
-        """platform from CMEMS005001MetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_platform({}),
-            OrderedDict([('Category', 'Models/Analyses'),
-                         ('Series_Entity', ''),
-                         ('Short_Name', 'OPERATIONAL MODELS'),
-                         ('Long_Name', '')]))
-
-    def test_instrument(self):
-        """instrument from CMEMS005001MetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_instrument({}),
-            OrderedDict([('Category', 'In Situ/Laboratory Instruments'),
-                         ('Class', 'Data Analysis'),
-                         ('Type', 'Environmental Modeling'),
-                         ('Subtype', ''),
-                         ('Short_Name', 'Computer'),
-                         ('Long_Name', 'Computer')]))
-
     def test_location_geometry(self):
         """geometry from CMEMS005001MetadataNormalizer """
         self.assertEqual(
@@ -929,11 +857,17 @@ class CMEMS005001MetadataNormalizerTestCase(unittest.TestCase):
                    'cmems_mod_ibi_phy_anfc_0.027deg-2D_PT15M-m/2020/12/'
                    'CMEMS_v5r1_IBI_PHY_NRT_PdE_15minav_20201212_20201212_R20201221_AN04.nc'
         }
-        self.assertListEqual(self.normalizer.get_dataset_parameters(attributes), [
-            DATASET_PARAMETERS['sea_surface_height_above_geoid'],
-            DATASET_PARAMETERS['eastward_sea_water_velocity'],
-            DATASET_PARAMETERS['northward_sea_water_velocity']
-        ])
+        with mock.patch('metanorm.utils.create_parameter_list') as mock_utils_method:
+            self.assertEqual(
+                self.normalizer.get_dataset_parameters(attributes),
+                mock_utils_method.return_value)
+            mock_utils_method.assert_called_once_with(
+                (
+                    'sea_surface_height_above_geoid',
+                    'eastward_sea_water_velocity',
+                    'northward_sea_water_velocity',
+                )
+            )
 
     def test_dataset_parameters_daily(self):
         """Should return the proper dataset parameters"""
@@ -942,15 +876,21 @@ class CMEMS005001MetadataNormalizerTestCase(unittest.TestCase):
             'cmems_mod_ibi_phy_anfc_0.027deg-3D_P1D-m/2021/05/'
             'CMEMS_v5r1_IBI_PHY_NRT_PdE_01dav_20210503_20210503_R20210510_AN06.nc'
         }
-        self.assertListEqual(self.normalizer.get_dataset_parameters(attributes), [
-            DATASET_PARAMETERS['sea_water_potential_temperature'],
-            DATASET_PARAMETERS['sea_water_salinity'],
-            DATASET_PARAMETERS['eastward_sea_water_velocity'],
-            DATASET_PARAMETERS['northward_sea_water_velocity'],
-            DATASET_PARAMETERS['sea_surface_height_above_geoid'],
-            DATASET_PARAMETERS['ocean_mixed_layer_thickness_defined_by_sigma_theta'],
-            DATASET_PARAMETERS['sea_water_potential_temperature_at_sea_floor'],
-        ])
+        with mock.patch('metanorm.utils.create_parameter_list') as mock_utils_method:
+            self.assertEqual(
+                self.normalizer.get_dataset_parameters(attributes),
+                mock_utils_method.return_value)
+            mock_utils_method.assert_called_once_with(
+                (
+                    'sea_water_potential_temperature',
+                    'sea_water_salinity',
+                    'eastward_sea_water_velocity',
+                    'northward_sea_water_velocity',
+                    'sea_surface_height_above_geoid',
+                    'ocean_mixed_layer_thickness_defined_by_sigma_theta',
+                    'sea_water_potential_temperature_at_sea_floor',
+                )
+            )
 
     def test_dataset_parameters_hourly(self):
         """Should return the proper dataset parameters"""
@@ -959,16 +899,21 @@ class CMEMS005001MetadataNormalizerTestCase(unittest.TestCase):
             'cmems_mod_ibi_phy_anfc_0.027deg-2D_PT1H-m/2019/11/'
             'CMEMS_v5r1_IBI_PHY_NRT_PdE_01hav_20191112_20191112_R20191113_AN07.nc'
         }
-        self.assertListEqual(self.normalizer.get_dataset_parameters(attributes), [
-            DATASET_PARAMETERS['sea_water_potential_temperature'],
-            DATASET_PARAMETERS['eastward_sea_water_velocity'],
-            DATASET_PARAMETERS['northward_sea_water_velocity'],
-            DATASET_PARAMETERS['barotropic_eastward_sea_water_velocity'],
-            DATASET_PARAMETERS['barotropic_northward_sea_water_velocity'],
-            DATASET_PARAMETERS['sea_surface_height_above_geoid'],
-            DATASET_PARAMETERS['ocean_mixed_layer_thickness_defined_by_sigma_theta'],
-
-        ])
+        with mock.patch('metanorm.utils.create_parameter_list') as mock_utils_method:
+            self.assertEqual(
+                self.normalizer.get_dataset_parameters(attributes),
+                mock_utils_method.return_value)
+            mock_utils_method.assert_called_once_with(
+                (
+                    'sea_water_potential_temperature',
+                    'eastward_sea_water_velocity',
+                    'northward_sea_water_velocity',
+                    'barotropic_eastward_sea_water_velocity',
+                    'barotropic_northward_sea_water_velocity',
+                    'sea_surface_height_above_geoid',
+                    'ocean_mixed_layer_thickness_defined_by_sigma_theta',
+                )
+            )
 
     def test_dataset_parameters_hourly3d(self):
         """Should return the proper dataset parameters"""
@@ -977,12 +922,18 @@ class CMEMS005001MetadataNormalizerTestCase(unittest.TestCase):
             'cmems_mod_ibi_phy_anfc_0.027deg-3D_PT1H-m/2021/08/'
             'CMEMS_v5r1_IBI_PHY_NRT_PdE_01hav3D_20210815_20210815_R20210816_HC01.nc'
         }
-        self.assertListEqual(self.normalizer.get_dataset_parameters(attributes), [
-            DATASET_PARAMETERS['sea_water_potential_temperature'],
-            DATASET_PARAMETERS['sea_water_salinity'],
-            DATASET_PARAMETERS['eastward_sea_water_velocity'],
-            DATASET_PARAMETERS['northward_sea_water_velocity'],
-        ])
+        with mock.patch('metanorm.utils.create_parameter_list') as mock_utils_method:
+            self.assertEqual(
+                self.normalizer.get_dataset_parameters(attributes),
+                mock_utils_method.return_value)
+            mock_utils_method.assert_called_once_with(
+                (
+                    'sea_water_potential_temperature',
+                    'sea_water_salinity',
+                    'eastward_sea_water_velocity',
+                    'northward_sea_water_velocity',
+                )
+            )
 
     def test_dataset_parameters_monthly(self):
         """Should return the proper dataset parameters"""
@@ -991,15 +942,21 @@ class CMEMS005001MetadataNormalizerTestCase(unittest.TestCase):
                    'cmems_mod_ibi_phy_anfc_0.027deg-3D_P1M-m/2019/'
                    'CMEMS_v5r1_IBI_PHY_NRT_PdE_01mav_20191001_20191031_R20191031_AN01.nc'
         }
-        self.assertListEqual(self.normalizer.get_dataset_parameters(attributes), [
-            DATASET_PARAMETERS['sea_water_potential_temperature'],
-            DATASET_PARAMETERS['sea_water_salinity'],
-            DATASET_PARAMETERS['eastward_sea_water_velocity'],
-            DATASET_PARAMETERS['northward_sea_water_velocity'],
-            DATASET_PARAMETERS['sea_surface_height_above_geoid'],
-            DATASET_PARAMETERS['ocean_mixed_layer_thickness_defined_by_sigma_theta'],
-            DATASET_PARAMETERS['sea_water_potential_temperature_at_sea_floor'],
-        ])
+        with mock.patch('metanorm.utils.create_parameter_list') as mock_utils_method:
+            self.assertEqual(
+                self.normalizer.get_dataset_parameters(attributes),
+                mock_utils_method.return_value)
+            mock_utils_method.assert_called_once_with(
+                (
+                    'sea_water_potential_temperature',
+                    'sea_water_salinity',
+                    'eastward_sea_water_velocity',
+                    'northward_sea_water_velocity',
+                    'sea_surface_height_above_geoid',
+                    'ocean_mixed_layer_thickness_defined_by_sigma_theta',
+                    'sea_water_potential_temperature_at_sea_floor'
+                )
+            )
 
     def test_dataset_parameters_unknown_url(self):
         """Should return an empty list if the URL starts with an
@@ -1011,3 +968,625 @@ class CMEMS005001MetadataNormalizerTestCase(unittest.TestCase):
         """An exception must be raised if the attribute is missing"""
         with self.assertRaises(MetadataNormalizationError):
             self.normalizer.get_dataset_parameters({})
+
+
+class CMEMS002003MetadataNormalizerTestCase(GCMDTestsMixin, unittest.TestCase):
+    """Tests for the CMEMS002003MetadataNormalizer class"""
+
+    def setUp(self):
+        self.normalizer = normalizers.geospaas.CMEMS002003MetadataNormalizer()
+
+    def test_check(self):
+        """Test the checking condition"""
+        self.assertTrue(self.normalizer.check({
+            'url': 'ftp://my.cmems-du.eu/Core/ARCTIC_MULTIYEAR_PHY_002_003/'
+                    'cmems_mod_arc_phy_my_topaz4_P1D-m/2021/02/'
+                    '20210204_dm-12km-NERSC-MODEL-TOPAZ4B-ARC-RAN.fv2.0.nc'}))
+
+        self.assertFalse(self.normalizer.check({}))
+        self.assertFalse(self.normalizer.check({'url': 'ftp://foo/bar'}))
+
+    def test_entry_title(self):
+        """test getting entry_title"""
+        self.assertEqual(
+            self.normalizer.get_entry_title({}),
+            'Arctic Ocean Physics Reanalysis')
+
+    def test_summary(self):
+        """test getting summary"""
+        self.assertEqual(
+            self.normalizer.get_summary({}),
+            'Description: The current version of the TOPAZ system - TOPAZ4b - is nearly identical '
+                'to the real-time forecast system run at MET Norway. It uses a recent version of '
+                'the Hybrid Coordinate Ocean Model (HYCOM) developed at University of Miami (Bleck '
+                '2002). HYCOM is coupled to a sea ice model; ice thermodynamics are described in '
+                'Drange and Simonsen (1996) and the elastic-viscous-plastic rheology in Hunke and '
+                'Dukowicz (1997).;'
+            'Processing level: 4;'
+            'Product: ARCTIC_MULTIYEAR_PHY_002_003')
+
+    def test_time_coverage_start_dm(self):
+        """Should return the proper starting time"""
+        self.assertEqual(
+            self.normalizer.get_time_coverage_start({
+                'url': 'ftp://my.cmems-du.eu/Core/ARCTIC_MULTIYEAR_PHY_002_003/'
+                       'cmems_mod_arc_phy_my_topaz4_P1D-m/2021/02/'
+                       '20210204_dm-12km-NERSC-MODEL-TOPAZ4B-ARC-RAN.fv2.0.nc'
+            }),
+            datetime(year=2021, month=2, day=4, hour=0, minute=0, second=0, tzinfo=timezone.utc))
+
+    def test_time_coverage_start_mm(self):
+        """Should return the proper starting time"""
+        self.assertEqual(
+            self.normalizer.get_time_coverage_start({
+                'url': 'ftp://my.cmems-du.eu/Core/ARCTIC_MULTIYEAR_PHY_002_003/'
+                       'cmems_mod_arc_phy_my_topaz4_P1M/'
+                       '19910115_mm-12km-NERSC-MODEL-TOPAZ4B-ARC-RAN.fv2.0.nc'
+            }),
+            datetime(year=1991, month=1, day=1, hour=0, minute=0, second=0, tzinfo=timezone.utc))
+
+    def test_time_coverage_start_ym(self):
+        """Should return the proper starting time"""
+        self.assertEqual(
+            self.normalizer.get_time_coverage_start({
+                'url': 'ftp://my.cmems-du.eu/Core/ARCTIC_MULTIYEAR_PHY_002_003/'
+                'cmems_mod_arc_phy_my_topaz4_P1M/'
+                '19910101_ym-12km-NERSC-MODEL-TOPAZ4B-ARC-RAN.fv2.0.nc'
+            }),
+            datetime(year=1991, month=1, day=1, hour=0, minute=0, second=0, tzinfo=timezone.utc))
+
+    def test_time_coverage_end_dm(self):
+        """Should return the proper end time"""
+        self.assertEqual(
+            self.normalizer.get_time_coverage_end({
+                'url': 'ftp://my.cmems-du.eu/Core/ARCTIC_MULTIYEAR_PHY_002_003/'
+                       'cmems_mod_arc_phy_my_topaz4_P1D-m/2021/02/'
+                       '20210204_dm-12km-NERSC-MODEL-TOPAZ4B-ARC-RAN.fv2.0.nc'
+            }),
+            datetime(year=2021, month=2, day=5, hour=0, minute=0, second=0, tzinfo=timezone.utc))
+
+    def test_time_coverage_end_mm(self):
+        """Should return the proper end time"""
+        self.assertEqual(
+            self.normalizer.get_time_coverage_end({
+                'url': 'ftp://my.cmems-du.eu/Core/ARCTIC_MULTIYEAR_PHY_002_003/'
+                       'cmems_mod_arc_phy_my_topaz4_P1M/'
+                       '19910115_mm-12km-NERSC-MODEL-TOPAZ4B-ARC-RAN.fv2.0.nc'
+            }),
+            datetime(year=1991, month=2, day=1, hour=0, minute=0, second=0, tzinfo=timezone.utc))
+
+    def test_time_coverage_end_ym(self):
+        """Should return the proper end time"""
+        self.assertEqual(
+            self.normalizer.get_time_coverage_end({
+                'url': 'ftp://my.cmems-du.eu/Core/ARCTIC_MULTIYEAR_PHY_002_003/'
+                       'cmems_mod_arc_phy_my_topaz4_P1M/'
+                       '19910101_ym-12km-NERSC-MODEL-TOPAZ4B-ARC-RAN.fv2.0.nc'
+            }),
+            datetime(year=1992, month=1, day=1, hour=0, minute=0, second=0, tzinfo=timezone.utc))
+
+    def test_location_geometry(self):
+        """test getting geometry"""
+        self.assertEqual(
+            self.normalizer.get_location_geometry({}),
+            'POLYGON((-180 53, -180 90, 180 90, 180 53, -180 53))')
+
+
+class CMEMS002001aMetadataNormalizerTestCase(GCMDTestsMixin, unittest.TestCase):
+    """Tests for the CMEMS002001aMetadataNormalizer class"""
+
+    def setUp(self):
+        self.normalizer = normalizers.geospaas.CMEMS002001aMetadataNormalizer()
+
+    def test_check(self):
+        """Test the checking condition"""
+        self.assertTrue(self.normalizer.check({
+            'url': 'ftp://nrt.cmems-du.eu/Core/ARCTIC_ANALYSIS_FORECAST_PHYS_002_001_a/'
+                   'dataset-topaz4-arc-myoceanv2-be/'
+                   '20180104_dm-metno-MODEL-topaz4-ARC-b20180108-fv02.0.nc'}))
+
+        self.assertFalse(self.normalizer.check({}))
+        self.assertFalse(self.normalizer.check({'url': 'ftp://foo/bar'}))
+
+    def test_entry_title(self):
+        """test getting entry_title"""
+        self.assertEqual(
+            self.normalizer.get_entry_title({}),
+            'Arctic Ocean Physics Analysis and Forecast')
+
+    def test_summary(self):
+        """test getting summary"""
+        self.assertEqual(
+            self.normalizer.get_summary({}),
+            'Description: The operational TOPAZ4 Arctic Ocean system uses the HYCOM model and a '
+            '100-member EnKF assimilation scheme. It is run daily to provide 10 days of forecast'
+            '(average of 10 members) of the 3D physical ocean, including sea ice data assimilation '
+            'is performed weekly to provide 7 days of analysis(ensemble average). Output products '
+            'are interpolated on a grid of 12.5 km resolution at the North Pole (equivalent to '
+            '1/8 deg in mid-latitudes) on a polar stereographic projection.;'
+            'Processing level: 4;'
+            'Product: ARCTIC_ANALYSIS_FORECAST_PHYS_002_001_a')
+
+    def test_time_coverage_start_dm(self):
+        """Should return the proper starting time"""
+        self.assertEqual(
+            self.normalizer.get_time_coverage_start({
+                'url': 'ftp://nrt.cmems-du.eu/Core/ARCTIC_ANALYSIS_FORECAST_PHYS_002_001_a/'
+                       'dataset-topaz4-arc-myoceanv2-be/'
+                       '20180104_dm-metno-MODEL-topaz4-ARC-b20180108-fv02.0.nc'
+            }),
+            datetime(year=2018, month=1, day=4, hour=0, minute=0, second=0, tzinfo=timezone.utc))
+
+    def test_time_coverage_start_hourly(self):
+        """Should return the proper starting time"""
+        self.assertEqual(
+            self.normalizer.get_time_coverage_start({
+                'url': 'ftp://nrt.cmems-du.eu/Core/ARCTIC_ANALYSIS_FORECAST_PHYS_002_001_a/'
+                       'dataset-topaz4-arc-1hr-myoceanv2-be/'
+                       '20180102_hr-metno-MODEL-topaz4-ARC-b20180102-fv02.0.nc'
+            }),
+            datetime(year=2018, month=1, day=2, hour=0, minute=0, second=0, tzinfo=timezone.utc))
+
+    def test_time_coverage_end_dm(self):
+        """Should return the proper end time"""
+        self.assertEqual(
+            self.normalizer.get_time_coverage_end({
+                'url': 'ftp://nrt.cmems-du.eu/Core/ARCTIC_ANALYSIS_FORECAST_PHYS_002_001_a/'
+                       'dataset-topaz4-arc-myoceanv2-be/'
+                       '20180104_dm-metno-MODEL-topaz4-ARC-b20180108-fv02.0.nc'
+            }),
+            datetime(year=2018, month=1, day=5, hour=0, minute=0, second=0, tzinfo=timezone.utc))
+
+    def test_time_coverage_end_hourly(self):
+        """Should return the proper end time"""
+        self.assertEqual(
+            self.normalizer.get_time_coverage_end({
+                'url': 'ftp://nrt.cmems-du.eu/Core/ARCTIC_ANALYSIS_FORECAST_PHYS_002_001_a/'
+                       'dataset-topaz4-arc-1hr-myoceanv2-be/'
+                       '20180102_hr-metno-MODEL-topaz4-ARC-b20180102-fv02.0.nc'
+            }),
+            datetime(year=2018, month=1, day=3, hour=0, minute=0, second=0, tzinfo=timezone.utc))
+
+    def test_location_geometry(self):
+        """test getting geometry"""
+        self.assertEqual(
+            self.normalizer.get_location_geometry({}),
+            'POLYGON((-180 62, -180 90, 180 90, 180 62, -180 62))')
+
+    def test_unknown_parameters(self):
+        """In case of unknown parameters, return an empty list"""
+        self.assertEqual(self.normalizer.get_dataset_parameters({'url': 'https://foo'}), [])
+
+
+class CMEMS002001MetadataNormalizerTestCase(GCMDTestsMixin, unittest.TestCase):
+    """Tests for the CMEMS002001MetadataNormalizer class"""
+
+    def setUp(self):
+        self.normalizer = normalizers.geospaas.CMEMS002001MetadataNormalizer()
+
+    def test_check(self):
+        """Test the checking condition"""
+        self.assertTrue(self.normalizer.check({
+            'url': 'https://thredds.met.no/thredds/dodsC/cmems/topaz5_phy_dm_files/2022/'
+                   '09/20220929_dm-metno-MODEL-topaz5-ARC-b20220922-fv02.0.nc.html'}))
+
+        self.assertFalse(self.normalizer.check({}))
+        self.assertFalse(self.normalizer.check({'url': 'https://foo/bar'}))
+
+    def test_provider(self):
+        """Test that we get the right provider if a CMEMS URL is used
+        """
+        with mock.patch('metanorm.utils.get_gcmd_provider') as mock_get_provider:
+            self.normalizer.get_provider({})
+            mock_get_provider.assert_called_with(['NO/MET'])
+
+    def test_entry_title(self):
+        """test getting entry_title"""
+        self.assertEqual(
+            self.normalizer.get_entry_title({}),
+            'Arctic Ocean Physics Analysis and Forecast, 6.25 km')
+
+    def test_summary(self):
+        """test getting summary"""
+        self.assertEqual(
+            self.normalizer.get_summary({}),
+            'Description: TOPAZ 5 physical model;'
+            'Processing level: 4;'
+            'Product: ARCTIC_ANALYSISFORECAST_PHY_002_001')
+
+    def test_time_coverage_start_dm(self):
+        """Should return the proper starting time"""
+        self.assertEqual(
+            self.normalizer.get_time_coverage_start({
+                'url': 'https://thredds.met.no/thredds/dodsC/cmems/topaz5_phy_dm_files/2022/09/'
+                       '20220929_dm-metno-MODEL-topaz5-ARC-b20220922-fv02.0.nc.html'
+            }),
+            datetime(year=2022, month=9, day=29, hour=0, minute=0, second=0, tzinfo=timezone.utc))
+
+    def test_time_coverage_start_hourly(self):
+        """Should return the proper starting time"""
+        self.assertEqual(
+            self.normalizer.get_time_coverage_start({
+                'url': 'https://thredds.met.no/thredds/dodsC/cmems/topaz5_phy_hr_files/2021/11/'
+                       '20211130_hr-metno-MODEL-topaz5-ARC-b20211130-fv02.0.nc.html'
+            }),
+            datetime(year=2021, month=11, day=30, hour=0, minute=0, second=0, tzinfo=timezone.utc))
+
+    def test_time_coverage_end_dm(self):
+        """Should return the proper end time"""
+        self.assertEqual(
+            self.normalizer.get_time_coverage_end({
+                'url': 'https://thredds.met.no/thredds/dodsC/cmems/topaz5_phy_dm_files/2022/09/'
+                       '20220929_dm-metno-MODEL-topaz5-ARC-b20220922-fv02.0.nc.html'
+            }),
+            datetime(year=2022, month=9, day=30, hour=0, minute=0, second=0, tzinfo=timezone.utc))
+
+    def test_time_coverage_end_hourly(self):
+        """Should return the proper end time"""
+        self.assertEqual(
+            self.normalizer.get_time_coverage_end({
+                'url': 'https://thredds.met.no/thredds/dodsC/cmems/topaz5_phy_hr_files/2021/11/'
+                       '20211130_hr-metno-MODEL-topaz5-ARC-b20211130-fv02.0.nc.html'
+            }),
+            datetime(year=2021, month=12, day=1, hour=0, minute=0, second=0, tzinfo=timezone.utc))
+
+    def test_location_geometry(self):
+        """test getting geometry"""
+        self.assertEqual(
+            self.normalizer.get_location_geometry({}),
+            'POLYGON((-180 50, -180 90, 180 90, 180 50, -180 50))')
+
+    def test_dataset_parameters(self):
+        """Test getting the dataset parameters"""
+        with mock.patch('metanorm.utils.create_parameter_list') as mock_utils_method:
+            with self.subTest('hourly'):
+                attributes = {
+                    'url': 'https://thredds.met.no/thredds/dodsC/cmems/topaz5_phy_hr_files/2021/11/'
+                        '20211130_hr-metno-MODEL-topaz5-ARC-b20211130-fv02.0.nc.html'
+                }
+                self.assertEqual(
+                    self.normalizer.get_dataset_parameters(attributes),
+                    mock_utils_method.return_value)
+                mock_utils_method.assert_called_with(
+                    (
+                        'longitude',
+                        'latitude',
+                        'sea_floor_depth_below_geoid',
+                        'sea_water_salinity',
+                        'sea_water_potential_temperature',
+                        'sea_ice_area_fraction',
+                        'sea_ice_thickness',
+                        'surface_snow_thickness',
+                        'sea_ice_x_velocity',
+                        'sea_ice_y_velocity',
+                        'sea_surface_height_above_geoid',
+                        'sea_water_x_velocity',
+                        'sea_water_y_velocity',
+                    )
+                )
+            with self.subTest('daily mean'):
+                attributes = {
+                    'url': 'https://thredds.met.no/thredds/dodsC/cmems/topaz5_phy_dm_files/2022/09/'
+                        '20220929_dm-metno-MODEL-topaz5-ARC-b20220922-fv02.0.nc.html'
+                }
+                self.assertEqual(
+                    self.normalizer.get_dataset_parameters(attributes),
+                    mock_utils_method.return_value)
+                mock_utils_method.assert_called_with(
+                    (
+                        'longitude',
+                        'latitude',
+                        'depth',
+                        'sea_floor_depth_below_geoid',
+                        'sea_water_potential_temperature',
+                        'sea_water_salinity',
+                        'sea_water_x_velocity',
+                        'sea_water_y_velocity',
+                        'ocean_mixed_layer_thickness_defined_by_sigma_theta',
+                        'sea_surface_height_above_geoid',
+                        'ocean_barotropic_streamfunction',
+                        'sea_ice_area_fraction',
+                        'sea_ice_thickness',
+                        'sea_ice_x_velocity',
+                        'sea_ice_y_velocity',
+                        'surface_snow_thickness',
+                        'age_of_sea_ice',
+                        'sea_ice_classification',
+                        'sea_ice_albedo',
+                        'sea_water_potential_temperature_at_sea_floor',
+                    )
+                )
+            with self.subTest('unknown'):
+                self.assertEqual(self.normalizer.get_dataset_parameters({'url': 'https://foo'}), [])
+
+
+class CMEMS002004MetadataNormalizerTestCase(GCMDTestsMixin, unittest.TestCase):
+    """Tests for the CMEMS002004MetadataNormalizer class"""
+
+    def setUp(self):
+        self.normalizer = normalizers.geospaas.CMEMS002004MetadataNormalizer()
+
+    def test_check(self):
+        """Test the checking condition"""
+        self.assertTrue(self.normalizer.check({
+            'url': 'https://thredds.met.no/thredds/dodsC/cmems/topaz5_bgc_dm_files/2021/10/'
+                   '20211031_dm-metno-MODEL-topaz5_ecosmo-ARC-b20211028-fv02.0.nc.html'}))
+
+        self.assertFalse(self.normalizer.check({}))
+        self.assertFalse(self.normalizer.check({'url': 'https://foo/bar'}))
+
+    def test_provider(self):
+        """Test that we get the right provider if a CMEMS URL is used
+        """
+        with mock.patch('metanorm.utils.get_gcmd_provider') as mock_get_provider:
+            with self.subTest('cmems'):
+                self.normalizer.get_provider({
+                    'url': 'ftp://nrt.cmems-du.eu/Core/ARCTIC_ANALYSISFORECAST_BGC_002_004/'
+                           'cmems_mod_arc_bgc_anfc_ecosmo_P1D-m'})
+                mock_get_provider.assert_called_with(['CMEMS'])
+            with self.subTest('met.no'):
+                self.normalizer.get_provider({
+                    'url': 'https://thredds.met.no/thredds/dodsC/cmems/topaz5_bgc_dm_files'})
+                mock_get_provider.assert_called_with(['NO/MET'])
+            with self.subTest('unknown'):
+                self.assertIsNone(self.normalizer.get_provider({'url': 'https://foo'}))
+
+    def test_entry_title(self):
+        """test getting entry_title"""
+        self.assertEqual(
+            self.normalizer.get_entry_title({}),
+            'Arctic Ocean Biogeochemistry Analysis and Forecast, 6.25 km')
+
+    def test_summary(self):
+        """test getting summary"""
+        self.assertEqual(
+            self.normalizer.get_summary({}),
+            'Description: TOPAZ 5 biochemistry model;'
+            'Processing level: 4;'
+            'Product: ARCTIC_ANALYSISFORECAST_BGC_002_004')
+
+    def test_time_coverage_start_dm(self):
+        """Should return the proper starting time"""
+        self.assertEqual(
+            self.normalizer.get_time_coverage_start({
+                'url': 'https://thredds.met.no/thredds/dodsC/cmems/topaz5_bgc_dm_files/2021/10/'
+                       '20211031_dm-metno-MODEL-topaz5_ecosmo-ARC-b20211028-fv02.0.nc.html'
+            }),
+            datetime(year=2021, month=10, day=31, hour=0, minute=0, second=0, tzinfo=timezone.utc))
+
+    def test_time_coverage_start_mm(self):
+        """Should return the proper starting time"""
+        self.assertEqual(
+            self.normalizer.get_time_coverage_start({
+                'url': 'https://thredds.met.no/thredds/dodsC/cmems/topaz5_bgc_mm_files/2020/'
+                       '202011_mm-metno-MODEL-topaz5_ecosmo-ARC-fv02.0.nc.html'
+            }),
+            datetime(year=2020, month=11, day=1, hour=0, minute=0, second=0, tzinfo=timezone.utc))
+
+    def test_time_coverage_end_dm(self):
+        """Should return the proper end time"""
+        self.assertEqual(
+            self.normalizer.get_time_coverage_end({
+                'url': 'https://thredds.met.no/thredds/dodsC/cmems/topaz5_bgc_dm_files/2021/10/'
+                       '20211031_dm-metno-MODEL-topaz5_ecosmo-ARC-b20211028-fv02.0.nc.html'
+            }),
+            datetime(year=2021, month=11, day=1, hour=0, minute=0, second=0, tzinfo=timezone.utc))
+
+    def test_time_coverage_end_mm(self):
+        """Should return the proper end time"""
+        self.assertEqual(
+            self.normalizer.get_time_coverage_end({
+                'url': 'https://thredds.met.no/thredds/dodsC/cmems/topaz5_bgc_mm_files/2020/'
+                       '202011_mm-metno-MODEL-topaz5_ecosmo-ARC-fv02.0.nc.html'
+            }),
+            datetime(year=2020, month=12, day=1, hour=0, minute=0, second=0, tzinfo=timezone.utc))
+
+    def test_location_geometry(self):
+        """test getting geometry"""
+        self.assertEqual(
+            self.normalizer.get_location_geometry({}),
+            'POLYGON((-180 50, -180 90, 180 90, 180 50, -180 50))')
+
+    def test_dataset_parameters(self):
+        """Test getting the dataset parameters"""
+        with mock.patch('metanorm.utils.create_parameter_list') as mock_utils_method:
+            with self.subTest('monthly mean'):
+                attributes = {
+                    'url': 'https://thredds.met.no/thredds/dodsC/cmems/topaz5_bgc_mm_files/2020/'
+                        '202011_mm-metno-MODEL-topaz5_ecosmo-ARC-fv02.0.nc.html'
+                }
+                self.assertEqual(
+                    self.normalizer.get_dataset_parameters(attributes),
+                    mock_utils_method.return_value)
+                mock_utils_method.assert_called_with(
+                    (
+                        'longitude',
+                        'latitude',
+                        'sea_floor_depth_below_geoid',
+                        ('net_primary_production_of_biomass_'
+                         'expressed_as_carbon_per_unit_volume_in_sea_water'),
+                        'mass_concentration_of_chlorophyll_a_in_sea_water',
+                        'volume_attenuation_coefficient_of_downwelling_radiative_flux_in_sea_water',
+                        'mole_concentration_of_nitrate_in_sea_water',
+                        'mole_concentration_of_phosphate_in_sea_water',
+                        'mole_concentration_of_phytoplankton_expressed_as_carbon_in_sea_water',
+                        'mole_concentration_of_zooplankton_expressed_as_carbon_in_sea_water',
+                        'mole_concentration_of_dissolved_molecular_oxygen_in_sea_water',
+                        'mole_concentration_of_silicate_in_sea_water',
+                        'sinking_mole_flux_of_particulate_organic_matter_'
+                        'expressed_as_carbon_in_sea_water',
+                        'sea_water_ph_reported_on_total_scale',
+                        'mole_concentration_of_dissolved_inorganic_carbon_in_sea_water',
+                        'surface_partial_pressure_of_carbon_dioxide_in_sea_water',
+                    )
+                )
+            with self.subTest('daily mean'):
+                attributes = {
+                    'url': 'https://thredds.met.no/thredds/dodsC/cmems/topaz5_bgc_dm_files/2021/10/'
+                        '20211031_dm-metno-MODEL-topaz5_ecosmo-ARC-b20211028-fv02.0.nc.html'
+                }
+
+                self.assertEqual(
+                    self.normalizer.get_dataset_parameters(attributes),
+                    mock_utils_method.return_value)
+                mock_utils_method.assert_called_with(
+                    (
+                        'longitude',
+                        'latitude',
+                        'depth',
+                        'sea_floor_depth_below_geoid',
+                        ('net_primary_production_of_biomass_'
+                         'expressed_as_carbon_per_unit_volume_in_sea_water'),
+                        'mass_concentration_of_chlorophyll_a_in_sea_water',
+                        'volume_attenuation_coefficient_of_downwelling_radiative_flux_in_sea_water',
+                        'mole_concentration_of_nitrate_in_sea_water',
+                        'mole_concentration_of_phosphate_in_sea_water',
+                        'mole_concentration_of_phytoplankton_expressed_as_carbon_in_sea_water',
+                        'mole_concentration_of_zooplankton_expressed_as_carbon_in_sea_water',
+                        'mole_concentration_of_dissolved_molecular_oxygen_in_sea_water',
+                        'mole_concentration_of_silicate_in_sea_water',
+                        'sinking_mole_flux_of_particulate_organic_matter_expressed_as_carbon_in_sea_water',
+                        'sea_water_ph_reported_on_total_scale',
+                        'mole_concentration_of_dissolved_inorganic_carbon_in_sea_water',
+                        'surface_partial_pressure_of_carbon_dioxide_in_sea_water',
+                    )
+                )
+            with self.subTest('unknown'):
+                self.assertEqual(self.normalizer.get_dataset_parameters({'url': 'https://foo'}), [])
+
+
+class CMEMS001027MetadataNormalizerTestCase(GCMDTestsMixin, unittest.TestCase):
+    """Tests for the CMEMS001027MetadataNormalizer class"""
+
+    def setUp(self):
+        self.normalizer = normalizers.geospaas.CMEMS001027MetadataNormalizer()
+
+    def test_check(self):
+        """Test the checking condition"""
+        self.assertTrue(self.normalizer.check({
+            'url': 'ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSISFORECAST_WAV_001_027/'
+            'cmems_mod_glo_wav_anfc_0.083deg_PT3H-i/2021/02/mfwamglocep_2021020200_R20210203.nc'}))
+
+        self.assertFalse(self.normalizer.check({}))
+        self.assertFalse(self.normalizer.check({'url': 'https://foo/bar'}))
+
+    def test_entry_title(self):
+        """entry_title from CMEMS001027MetadataNormalizer """
+        self.assertEqual(
+            self.normalizer.get_entry_title({}),
+            'Global Ocean Waves Analysis and Forecast')
+
+    def test_summary(self):
+        """summary from CMEMS001027MetadataNormalizer"""
+        self.assertEqual(
+            self.normalizer.get_summary({}),
+            'Description: '
+            'The operational global ocean analysis and forecast system of Météo-France with a '
+            'resolution of 1/12 degree is providing daily analyses and 10 days forecasts for the '
+            'global ocean sea surface waves. This product includes 3-hourly instantaneous fields of'
+            ' integrated wave parameters from the total spectrum (significant height, period, '
+            'direction, Stokes drift,...etc), as well as the following partitions: the wind wave, '
+            'the primary and secondary swell waves.;'
+            'Processing level: 4;'
+            'Product: GLOBAL_ANALYSISFORECAST_WAV_001_027')
+
+    def test_time_coverage_start(self):
+        """time_coverage_start from CMEMS001027MetadataNormalizer """
+        self.assertEqual(
+            self.normalizer.get_time_coverage_start({
+                'url': 'ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSISFORECAST_WAV_001_027/'
+                'cmems_mod_glo_wav_anfc_0.083deg_PT3H-i/'
+                '2021/02/mfwamglocep_2021020200_R20210203.nc'}),
+            datetime(year=2021, month=2, day=2, hour=0, minute=0, second=0, tzinfo=timezone.utc))
+
+    def test_time_coverage_end(self):
+        """time_coverage_start from CMEMS001027MetadataNormalizer"""
+        self.assertEqual(
+            self.normalizer.get_time_coverage_end({
+                'url': 'ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSISFORECAST_WAV_001_027/'
+                'cmems_mod_glo_wav_anfc_0.083deg_PT3H-i/'
+                '2021/02/mfwamglocep_2021020200_R20210203.nc'}),
+            datetime(year=2021, month=2, day=3, hour=0, minute=0, second=0, tzinfo=timezone.utc))
+
+    def test_location_geometry(self):
+        """geometry from CMEMS001027MetadataNormalizer """
+        self.assertEqual(
+            self.normalizer.get_location_geometry({}),
+            'POLYGON((-180 -90, -180 90, 180 90, 180 -90, -180 -90))')
+
+
+class CMEMS001028MetadataNormalizerTestCase(GCMDTestsMixin, unittest.TestCase):
+    """Tests for the CMEMS001028MetadataNormalizer class"""
+
+    def setUp(self):
+        self.normalizer = normalizers.geospaas.CMEMS001028MetadataNormalizer()
+
+    def test_check(self):
+        """Test the checking condition"""
+        self.assertTrue(self.normalizer.check({
+            'url': 'ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_BIO_001_028/'
+                   'global-analysis-forecast-bio-001-028-daily/'
+                   '2023/01/mercatorbiomer4v2r1_global_mean_20230103.nc'}))
+
+        self.assertFalse(self.normalizer.check({}))
+        self.assertFalse(self.normalizer.check({'url': 'https://foo/bar'}))
+
+    def test_entry_title(self):
+        """entry_title from CMEMS001028MetadataNormalizer """
+        self.assertEqual(
+            self.normalizer.get_entry_title({}),
+            'Global Ocean Biogeochemistry Analysis and Forecast')
+
+    def test_summary(self):
+        """summary from CMEMS001028MetadataNormalizer"""
+        self.assertEqual(
+            self.normalizer.get_summary({}),
+            'Description: '
+            'The Operational Mercator Ocean biogeochemical global ocean analysis and forecast '
+            'system at 1/4 degree is providing 10 days of 3D global ocean forecasts updated weekly.'
+            ' The time series is aggregated in time, in order to reach a two full year’s time '
+            'series sliding window.;'
+            'Processing level: 4;'
+            'Product: GLOBAL_ANALYSIS_FORECAST_BIO_001_028')
+
+    def test_time_coverage_start_daily(self):
+        """time_coverage_start from CMEMS001028MetadataNormalizer """
+        self.assertEqual(
+            self.normalizer.get_time_coverage_start({
+                'url': 'ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_BIO_001_028/'
+                       'global-analysis-forecast-bio-001-028-daily/'
+                       '2023/01/mercatorbiomer4v2r1_global_mean_20230103.nc'}),
+            datetime(year=2023, month=1, day=3, hour=0, minute=0, second=0, tzinfo=timezone.utc))
+
+    def test_time_coverage_start_monthly(self):
+        """time_coverage_start from CMEMS001028MetadataNormalizer """
+        self.assertEqual(
+            self.normalizer.get_time_coverage_start({
+                'url': 'ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_BIO_001_028/'
+                       'global-analysis-forecast-bio-001-028-monthly/'
+                       '2021/mercatorbiomer4v2r1_global_mean_202104.nc'}),
+            datetime(year=2021, month=4, day=1, hour=0, minute=0, second=0, tzinfo=timezone.utc))
+
+    def test_time_coverage_end_daily(self):
+        """time_coverage_start from CMEMS001028MetadataNormalizer"""
+        self.assertEqual(
+            self.normalizer.get_time_coverage_end({
+                'url': 'ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_BIO_001_028/'
+                       'global-analysis-forecast-bio-001-028-daily/'
+                       '2023/01/mercatorbiomer4v2r1_global_mean_20230103.nc'}),
+            datetime(year=2023, month=1, day=4, hour=0, minute=0, second=0, tzinfo=timezone.utc))
+
+    def test_time_coverage_end_monthly(self):
+        """time_coverage_start from CMEMS001028MetadataNormalizer"""
+        self.assertEqual(
+            self.normalizer.get_time_coverage_end({
+                'url': 'ftp://nrt.cmems-du.eu/Core/GLOBAL_ANALYSIS_FORECAST_BIO_001_028/'
+                       'global-analysis-forecast-bio-001-028-monthly/'
+                       '2021/mercatorbiomer4v2r1_global_mean_202104.nc'}),
+            datetime(year=2021, month=5, day=1, hour=0, minute=0, second=0, tzinfo=timezone.utc))
+
+    def test_location_geometry(self):
+        """geometry from CMEMS001028MetadataNormalizer """
+        self.assertEqual(
+            self.normalizer.get_location_geometry({}),
+            'POLYGON((-180 -90, -180 90, 180 90, 180 -90, -180 -90))')

--- a/tests/normalizers/test_cmems_in_situ_tac.py
+++ b/tests/normalizers/test_cmems_in_situ_tac.py
@@ -1,5 +1,6 @@
 """Tests for the CMEMS in situ TAC metadata normalizer"""
 import unittest
+import unittest.mock as mock
 from collections import OrderedDict
 from datetime import datetime
 
@@ -187,34 +188,26 @@ class CMEMSInSituTACMetadataNormalizerTestCase(unittest.TestCase):
         with self.assertRaises(MetadataNormalizationError):
             self.normalizer.get_time_coverage_end({})
 
-    def test_get_platform(self):
-        """get_platform() should return the platform
-        of the dataset
-        """
-        self.assertEqual(
-            self.normalizer.get_platform({}),
-            OrderedDict([
-                ('Category', 'In Situ Ocean-based Platforms'),
-                ('Series_Entity', ''),
-                ('Short_Name', ''),
-                ('Long_Name', '')
-            ]))
+    def test_gcmd_platform(self):
+        """Test getting the platform"""
+        with mock.patch('metanorm.utils.get_gcmd_platform') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_platform({}),
+                mock_get_gcmd_method.return_value)
 
-    def test_get_instrument(self):
-        """get_instrument() should return the instrument
-        of the dataset
-        """
-        self.assertEqual(
-            self.normalizer.get_instrument({}),
-            OrderedDict([
-                ('Category', 'In Situ/Laboratory Instruments'),
-                ('Class', ''),
-                ('Type', ''),
-                ('Subtype', ''),
-                ('Short_Name', ''),
-                ('Long_Name', '')
-            ])
-        )
+    def test_gcmd_instrument(self):
+        """Test getting the instrument"""
+        with mock.patch('metanorm.utils.get_gcmd_instrument') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_instrument({}),
+                mock_get_gcmd_method.return_value)
+
+    def test_gcmd_provider(self):
+        """Test getting the provider"""
+        with mock.patch('metanorm.utils.get_gcmd_provider') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_provider({}),
+                mock_get_gcmd_method.return_value)
 
     def test_get_location_geometry(self):
         """get_location_geometry() should return the location
@@ -228,19 +221,3 @@ class CMEMSInSituTACMetadataNormalizerTestCase(unittest.TestCase):
         attribute is missing
         """
         self.assertEqual(self.normalizer.get_location_geometry({}), '')
-
-    def test_get_provider(self):
-        """get_provider() should return the provider
-        of the dataset
-        """
-        self.assertEqual(
-            self.normalizer.get_provider({}),
-            OrderedDict([
-                ('Bucket_Level0', 'MULTINATIONAL ORGANIZATIONS'),
-                ('Bucket_Level1', ''),
-                ('Bucket_Level2', ''),
-                ('Bucket_Level3', ''),
-                ('Short_Name', 'CMEMS'),
-                ('Long_Name', 'Copernicus - Marine Environment Monitoring Service'),
-                ('Data_Center_URL', '')
-            ]))

--- a/tests/normalizers/test_cpom.py
+++ b/tests/normalizers/test_cpom.py
@@ -1,11 +1,10 @@
 """Tests for the CPOM altimetry normalizer"""
 
 import unittest
-from collections import OrderedDict
+import unittest.mock as mock
 from datetime import datetime, timezone
 
 import metanorm.normalizers as normalizers
-from metanorm.errors import MetadataNormalizationError
 
 
 class CPOMAltimetryMetadataNormalizerTests(unittest.TestCase):
@@ -38,28 +37,26 @@ class CPOMAltimetryMetadataNormalizerTests(unittest.TestCase):
             self.normalizer.get_time_coverage_end({}),
             datetime(year=2015, month=1, day=1, tzinfo=timezone.utc))
 
-    def test_get_platform(self):
+    def test_gcmd_platform(self):
         """Test getting the platform"""
-        self.assertDictEqual(self.normalizer.get_platform({}),
-            OrderedDict([
-                ('Category', 'Earth Observation Satellites'),
-                ('Series_Entity', ''),
-                ('Short_Name', ''),
-                ('Long_Name', '')
-            ]))
+        with mock.patch('metanorm.utils.get_gcmd_platform') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_platform({}),
+                mock_get_gcmd_method.return_value)
 
-    def test_get_instrument(self):
+    def test_gcmd_instrument(self):
         """Test getting the instrument"""
-        self.assertDictEqual(
-            self.normalizer.get_instrument({}),
-            OrderedDict([
-                ('Category', 'Earth Remote Sensing Instruments'),
-                ('Class', 'Active Remote Sensing'),
-                ('Type', 'Altimeters'),
-                ('Subtype', ''),
-                ('Short_Name', ''),
-                ('Long_Name', '')
-            ]))
+        with mock.patch('metanorm.utils.get_gcmd_instrument') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_instrument({}),
+                mock_get_gcmd_method.return_value)
+
+    def test_gcmd_provider(self):
+        """Test getting the provider"""
+        with mock.patch('metanorm.utils.get_gcmd_provider') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_provider({}),
+                mock_get_gcmd_method.return_value)
 
     def test_get_location_geometry(self):
         """get_location_geometry() should return the location
@@ -74,30 +71,9 @@ class CPOMAltimetryMetadataNormalizerTests(unittest.TestCase):
         """
         self.assertEqual(self.normalizer.get_location_geometry({}), '')
 
-    def test_get_provider(self):
-        """Test getting the provider"""
-        self.assertDictEqual(
-            self.normalizer.get_provider({}),
-            OrderedDict([
-                ('Bucket_Level0', 'ACADEMIC'),
-                ('Bucket_Level1', ''),
-                ('Bucket_Level2', ''),
-                ('Bucket_Level3', ''),
-                ('Short_Name', 'UC-LONDON/CPOM'),
-                ('Long_Name', ''),
-                ('Data_Center_URL', 'http://www.cpom.ucl.ac.uk/cpom_ucl_only/data_resources.html')
-            ]))
-
-    def test_get_parameters(self):
-        """Test getting the only dataset parameter"""
-        self.assertListEqual(
-            self.normalizer.get_dataset_parameters({}),
-            [
-                OrderedDict([
-                    ('standard_name', 'sea_surface_height_above_sea_level'),
-                    ('long_name', 'Sea Surface Anomaly'),
-                    ('short_name', 'SSA'),
-                    ('units', 'm'),
-                    ('minmax', '-100 100'),
-                    ('colormap', 'jet')])
-            ])
+    def test_dataset_parameters(self):
+        """dataset_parameters from CEDAESACCIMetadataNormalizer """
+        with mock.patch('metanorm.utils.create_parameter_list') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_dataset_parameters({}),
+                mock_get_gcmd_method.return_value)

--- a/tests/normalizers/test_earthdata_cmr.py
+++ b/tests/normalizers/test_earthdata_cmr.py
@@ -1,6 +1,6 @@
 """Tests for the ACDD metadata normalizer"""
 import unittest
-from collections import OrderedDict
+import unittest.mock as mock
 from datetime import datetime
 
 from dateutil.tz import tzutc
@@ -163,24 +163,22 @@ class EarthdataCMRMetadataNormalizerTestCase(unittest.TestCase):
 
     def test_platform(self):
         """Test getting the platform"""
-        self.assertEqual(
-            self.normalizer.get_platform({'umm': {
-                "Platforms": [
-                    {
-                        "ShortName": "SUOMI-NPP",
-                        "Instruments": [
-                            {
-                                "ShortName": "VIIRS"
-                            }
-                        ]
-                    }
-                ]
-            }}),
-            OrderedDict([('Category', 'Earth Observation Satellites'),
-                         ('Series_Entity', 'Joint Polar Satellite System (JPSS)'),
-                         ('Short_Name', 'Suomi-NPP'),
-                         ('Long_Name', 'Suomi National Polar-orbiting Partnership')]),
-        )
+        with mock.patch('metanorm.utils.get_gcmd_platform') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_platform({'umm': {
+                    "Platforms": [
+                        {
+                            "ShortName": "SUOMI-NPP",
+                            "Instruments": [
+                                {
+                                    "ShortName": "VIIRS"
+                                }
+                            ]
+                        }
+                    ]
+                }}),
+                mock_get_gcmd_method.return_value)
+            mock_get_gcmd_method.assert_called_with('SUOMI-NPP')
 
     def test_platform_missing_attribute(self):
         """A MetadataNormalizationError must be raised if the raw
@@ -193,26 +191,22 @@ class EarthdataCMRMetadataNormalizerTestCase(unittest.TestCase):
 
     def test_instrument(self):
         """Test getting the instrument"""
-        self.assertEqual(
-            self.normalizer.get_instrument({'umm': {
-                "Platforms": [
-                    {
-                        "ShortName": "SUOMI-NPP",
-                        "Instruments": [
-                            {
-                                "ShortName": "VIIRS"
-                            }
-                        ]
-                    }
-                ]
-            }}),
-            OrderedDict([('Category', 'Earth Remote Sensing Instruments'),
-                         ('Class', 'Passive Remote Sensing'),
-                         ('Type', 'Spectrometers/Radiometers'),
-                         ('Subtype', 'Imaging Spectrometers/Radiometers'),
-                         ('Short_Name', 'VIIRS'),
-                         ('Long_Name', 'Visible-Infrared Imager-Radiometer Suite')])
-        )
+        with mock.patch('metanorm.utils.get_gcmd_instrument') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_instrument({'umm': {
+                    "Platforms": [
+                        {
+                            "ShortName": "SUOMI-NPP",
+                            "Instruments": [
+                                {
+                                    "ShortName": "VIIRS"
+                                }
+                            ]
+                        }
+                    ]
+                }}),
+                mock_get_gcmd_method.return_value)
+            mock_get_gcmd_method.assert_called_with('VIIRS')
 
     def test_instrument_missing_attribute(self):
         """A MetadataNormalizationError must be raised if the raw
@@ -264,20 +258,11 @@ class EarthdataCMRMetadataNormalizerTestCase(unittest.TestCase):
 
     def test_get_provider(self):
         """Test getting the provider"""
-        self.assertEqual(
-            self.normalizer.get_provider({"meta": {"provider-id": "OB_DAAC"}}),
-            OrderedDict([('Bucket_Level0', 'GOVERNMENT AGENCIES-U.S. FEDERAL AGENCIES'),
-                         ('Bucket_Level1', 'NASA'),
-                         ('Bucket_Level2', ''),
-                         ('Bucket_Level3', ''),
-                         ('Short_Name', 'NASA/GSFC/SED/ESD/GCDC/OB.DAAC'),
-                         ('Long_Name',
-                          'Ocean Biology Distributed Active Archive Center (OB.DAAC), '
-                          'Global Change Data Center, Earth Sciences Division, '
-                          'Science and Exploration Directorate, '
-                          'Goddard Space Flight Center, NASA'),
-                         ('Data_Center_URL', 'https://oceancolor.gsfc.nasa.gov')])
-        )
+        with mock.patch('metanorm.utils.get_gcmd_provider') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_provider({"meta": {"provider-id": "OB_DAAC"}}),
+                mock_get_gcmd_method.return_value)
+            mock_get_gcmd_method.assert_called_with(['OB_DAAC'])
 
     def test_unknown_provider_returns_none(self):
         """A MetadataNormalizationError must be raised if the provider

--- a/tests/normalizers/test_geospaas_base.py
+++ b/tests/normalizers/test_geospaas_base.py
@@ -3,7 +3,6 @@
 import logging
 import unittest
 import unittest.mock as mock
-from collections import OrderedDict
 
 import metanorm.errors as errors
 import metanorm.normalizers as normalizers
@@ -74,10 +73,11 @@ class GeoSPaaSMetadataNormalizerTestCase(unittest.TestCase):
         """get_iso_topic_category() should return the "Oceans" keyword
         as default value
         """
-        self.assertDictEqual(
-            self.normalizer.get_iso_topic_category({}),
-            OrderedDict([('iso_topic_category', 'Oceans')])
-        )
+        with mock.patch('pythesint.get_iso19115_topic_category') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_iso_topic_category({}),
+                mock_get_gcmd_method.return_value)
+            mock_get_gcmd_method.assert_called_with('Oceans')
 
     def test_iso_topic_category_pti_error(self):
         """A MetadataNormalizationError must be raised in case of pythesint error"""
@@ -89,16 +89,11 @@ class GeoSPaaSMetadataNormalizerTestCase(unittest.TestCase):
         """get_gcmd_location() should return the "SEA SURFACE" keyword
         as default value
         """
-        self.assertDictEqual(
-            self.normalizer.get_gcmd_location({}),
-            OrderedDict([
-                ('Location_Category', 'VERTICAL LOCATION'),
-                ('Location_Type', 'SEA SURFACE'),
-                ('Location_Subregion1', ''),
-                ('Location_Subregion2', ''),
-                ('Location_Subregion3', '')
-            ])
-        )
+        with mock.patch('pythesint.get_gcmd_location') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_gcmd_location({}),
+                mock_get_gcmd_method.return_value)
+            mock_get_gcmd_method.assert_called_with('SEA SURFACE')
 
     def test_gcmd_location_pti_error(self):
         """A MetadataNormalizationError must be raised in case of pythesint error"""

--- a/tests/normalizers/test_gportal_gcom.py
+++ b/tests/normalizers/test_gportal_gcom.py
@@ -1,11 +1,10 @@
 """Tests for the GPortal GCOM-W normalizer"""
 import unittest
-from collections import OrderedDict
+import unittest.mock as mock
 from datetime import datetime
 from dateutil.tz import tzutc
 
 import metanorm.normalizers as normalizers
-from .data import DATASET_PARAMETERS
 from metanorm.errors import MetadataNormalizationError
 
 
@@ -97,25 +96,26 @@ class GPortalGCOMAMSR2L3MetadataNormalizerTestCase(unittest.TestCase):
         with self.assertRaises(MetadataNormalizationError):
             self.normalizer.get_time_coverage_end({})
 
-    def test_platform(self):
-        """platform from GPortalGCOMAMSR2L3MetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_platform({}),
-            OrderedDict([('Category', 'Earth Observation Satellites'),
-                         ('Series_Entity', ''),
-                         ('Short_Name', 'GCOM-W1'),
-                         ('Long_Name', 'Global Change Observation Mission 1st-Water')]))
+    def test_gcmd_platform(self):
+        """Test getting the platform"""
+        with mock.patch('metanorm.utils.get_gcmd_platform') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_platform({}),
+                mock_get_gcmd_method.return_value)
 
-    def test_instrument(self):
-        """instrument from GPortalGCOMAMSR2L3MetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_instrument({}),
-            OrderedDict([('Category', 'Earth Remote Sensing Instruments'),
-                         ('Class', 'Passive Remote Sensing'),
-                         ('Type', 'Spectrometers/Radiometers'),
-                         ('Subtype', 'Imaging Spectrometers/Radiometers'),
-                         ('Short_Name', 'AMSR2'),
-                         ('Long_Name', 'Advanced Microwave Scanning Radiometer 2')]))
+    def test_gcmd_instrument(self):
+        """Test getting the instrument"""
+        with mock.patch('metanorm.utils.get_gcmd_instrument') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_instrument({}),
+                mock_get_gcmd_method.return_value)
+
+    def test_gcmd_provider(self):
+        """Test getting the provider"""
+        with mock.patch('metanorm.utils.get_gcmd_provider') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_provider({}),
+                mock_get_gcmd_method.return_value)
 
     def test_location_geometry(self):
         """geometry from GPortalGCOMAMSR2L3MetadataNormalizer """
@@ -123,21 +123,9 @@ class GPortalGCOMAMSR2L3MetadataNormalizerTestCase(unittest.TestCase):
             self.normalizer.get_location_geometry({}),
             'POLYGON((-180 -90, -180 90, 180 90, 180 -90, -180 -90))')
 
-    def test_provider(self):
-        """provider from GPortalGCOMAMSR2L3MetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_provider({}),
-            OrderedDict([('Bucket_Level0', 'GOVERNMENT AGENCIES-NON-US'),
-                         ('Bucket_Level1', 'JAPAN'),
-                         ('Bucket_Level2', ''),
-                         ('Bucket_Level3', ''),
-                         ('Short_Name', 'JP/JAXA/EOC'),
-                         ('Long_Name', 'Earth Observation Center, Japan Aerospace Exploration '
-                                       'Agency, Japan'),
-                         ('Data_Center_URL', 'http://www.eorc.jaxa.jp/en/index.html')]))
-
     def test_dataset_parameters(self):
         """dataset_parameters from GPortalGCOMAMSR2L3MetadataNormalizer """
-        self.assertEqual(self.normalizer.get_dataset_parameters({}), [
-            DATASET_PARAMETERS['sea_surface_temperature']
-        ])
+        with mock.patch('metanorm.utils.create_parameter_list') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_dataset_parameters({}),
+                mock_get_gcmd_method.return_value)

--- a/tests/normalizers/test_nextsim.py
+++ b/tests/normalizers/test_nextsim.py
@@ -1,11 +1,10 @@
-"""Tests for the CPOM altimetry normalizer"""
+"""Tests for the nextsim normalizer"""
 
 import unittest
-from collections import OrderedDict
+import unittest.mock as mock
 from datetime import datetime, timezone
 
 import metanorm.normalizers as normalizers
-from .data import DATASET_PARAMETERS
 from metanorm.errors import MetadataNormalizationError
 
 
@@ -88,24 +87,26 @@ class NextsimMetadataNormalizerTests(unittest.TestCase):
         with self.assertRaises(MetadataNormalizationError):
             self.normalizer.get_time_coverage_end({})
 
-    def test_get_platform(self):
+    def test_gcmd_platform(self):
         """Test getting the platform"""
-        self.assertDictEqual(self.normalizer.get_platform({}),
-                             OrderedDict([('Category', 'Models/Analyses'),
-                                          ('Series_Entity', ''),
-                                          ('Short_Name', 'OPERATIONAL MODELS'),
-                                          ('Long_Name', '')]))
+        with mock.patch('metanorm.utils.get_gcmd_platform') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_platform({}),
+                mock_get_gcmd_method.return_value)
 
-    def test_get_instrument(self):
+    def test_gcmd_instrument(self):
         """Test getting the instrument"""
-        self.assertDictEqual(
-            self.normalizer.get_instrument({}),
-            OrderedDict([('Category', 'In Situ/Laboratory Instruments'),
-                         ('Class', 'Data Analysis'),
-                         ('Type', 'Environmental Modeling'),
-                         ('Subtype', ''),
-                         ('Short_Name', 'Computer'),
-                         ('Long_Name', 'Computer')]))
+        with mock.patch('metanorm.utils.get_gcmd_instrument') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_instrument({}),
+                mock_get_gcmd_method.return_value)
+
+    def test_gcmd_provider(self):
+        """Test getting the provider"""
+        with mock.patch('metanorm.utils.get_gcmd_provider') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_provider({}),
+                mock_get_gcmd_method.return_value)
 
     def test_get_location_geometry(self):
         """get_location_geometry() should return the location
@@ -114,46 +115,3 @@ class NextsimMetadataNormalizerTests(unittest.TestCase):
         self.assertEqual(
             self.normalizer.get_location_geometry({}),
             'POLYGON((-180 62,180 62,180 90,-180 90,-180 62))')
-
-    def test_get_provider(self):
-        """Test getting the provider"""
-        self.assertDictEqual(
-            self.normalizer.get_provider({}),
-            OrderedDict([
-                ('Bucket_Level0', 'CONSORTIA/INSTITUTIONS'),
-                ('Bucket_Level1', ''),
-                ('Bucket_Level2', ''),
-                ('Bucket_Level3', ''),
-                ('Short_Name', 'NERSC'),
-                ('Long_Name', 'Nansen Environmental and Remote Sensing Centre'),
-                ('Data_Center_URL', 'http://www.nersc.no/main/index2.php')]))
-
-    def test_get_parameters(self):
-        """Test getting the only dataset parameter"""
-        self.assertListEqual(
-            self.normalizer.get_dataset_parameters({
-                'raw_dataset_parameters': [
-                    'projection_y_coordinate',
-                    'projection_x_coordinate',
-                    'longitude',
-                    'latitude',
-                    'time',
-                    'sea_ice_area_fraction',
-                    'sea_ice_thickness',
-                    'surface_snow_thickness',
-                    'sea_ice_x_velocity',
-                    'sea_ice_y_velocity'
-                ],
-            }),
-            [
-                DATASET_PARAMETERS['projection_y_coordinate'],
-                DATASET_PARAMETERS['projection_x_coordinate'],
-                DATASET_PARAMETERS['longitude'],
-                DATASET_PARAMETERS['latitude'],
-                DATASET_PARAMETERS['time'],
-                DATASET_PARAMETERS['sea_ice_area_fraction'],
-                DATASET_PARAMETERS['sea_ice_thickness'],
-                DATASET_PARAMETERS['surface_snow_thickness'],
-                DATASET_PARAMETERS['sea_ice_x_velocity'],
-                DATASET_PARAMETERS['sea_ice_y_velocity']
-            ])

--- a/tests/normalizers/test_noaa_hycom.py
+++ b/tests/normalizers/test_noaa_hycom.py
@@ -1,11 +1,10 @@
 """Tests for the NOAA HYCOM normalizer"""
 import unittest
-from collections import OrderedDict
+import unittest.mock as mock
 from datetime import datetime
 from dateutil.tz import tzutc
 
 import metanorm.normalizers as normalizers
-from .data import DATASET_PARAMETERS
 from metanorm.errors import MetadataNormalizationError
 
 
@@ -145,25 +144,26 @@ class NOAAHYCOMMetadataNormalizerTestCase(unittest.TestCase):
         with self.assertRaises(MetadataNormalizationError):
             self.normalizer.get_time_coverage_end({})
 
-    def test_platform(self):
-        """platform from NOAAHYCOMMetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_platform({}),
-            OrderedDict([('Category', 'Models/Analyses'),
-                         ('Series_Entity', ''),
-                         ('Short_Name', 'OPERATIONAL MODELS'),
-                         ('Long_Name', '')]))
+    def test_gcmd_platform(self):
+        """Test getting the platform"""
+        with mock.patch('metanorm.utils.get_gcmd_platform') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_platform({}),
+                mock_get_gcmd_method.return_value)
 
-    def test_instrument(self):
-        """instrument from NOAAHYCOMMetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_instrument({}),
-            OrderedDict([('Category', 'In Situ/Laboratory Instruments'),
-                         ('Class', 'Data Analysis'),
-                         ('Type', 'Environmental Modeling'),
-                         ('Subtype', ''),
-                         ('Short_Name', 'Computer'),
-                         ('Long_Name', 'Computer')]))
+    def test_gcmd_instrument(self):
+        """Test getting the instrument"""
+        with mock.patch('metanorm.utils.get_gcmd_instrument') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_instrument({}),
+                mock_get_gcmd_method.return_value)
+
+    def test_gcmd_provider(self):
+        """Test getting the provider"""
+        with mock.patch('metanorm.utils.get_gcmd_provider') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_provider({}),
+                mock_get_gcmd_method.return_value)
 
     def test_geometry_hycom_region1(self):
         """Should return the proper geometry"""
@@ -225,29 +225,10 @@ class NOAAHYCOMMetadataNormalizerTestCase(unittest.TestCase):
         with self.assertRaises(MetadataNormalizationError):
             self.normalizer.get_location_geometry({'url': 'http://foo'})
 
-    def test_provider(self):
-        """provider from NOAAHYCOMMetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_provider({}),
-            OrderedDict([
-                ('Bucket_Level0', 'GOVERNMENT AGENCIES-U.S. FEDERAL AGENCIES'),
-                ('Bucket_Level1', 'DOC'),
-                ('Bucket_Level2', 'NOAA'),
-                ('Bucket_Level3', ''),
-                ('Short_Name', 'DOC/NOAA/NWS/NCEP'),
-                ('Long_Name',
-                 'National Centers for Environmental Prediction, National Weather Service, NOAA, '
-                 'U.S. Department of Commerce'),
-                ('Data_Center_URL', 'http://www.ncep.noaa.gov/')]))
 
     def test_dataset_parameters(self):
         """dataset_parameters from NOAAHYCOMMetadataNormalizer """
-        self.assertEqual(self.normalizer.get_dataset_parameters({}), [
-            DATASET_PARAMETERS['sea_water_salinity'],
-            DATASET_PARAMETERS['sea_water_temperature'],
-            DATASET_PARAMETERS['sea_water_salinity_at_bottom'],
-            DATASET_PARAMETERS['sea_water_temperature_at_bottom'],
-            DATASET_PARAMETERS['sea_surface_height_above_geoid'],
-            DATASET_PARAMETERS['eastward_sea_water_velocity'],
-            DATASET_PARAMETERS['northward_sea_water_velocity'],
-        ])
+        with mock.patch('metanorm.utils.create_parameter_list') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_dataset_parameters({}),
+                mock_get_gcmd_method.return_value)

--- a/tests/normalizers/test_noaa_rtofs.py
+++ b/tests/normalizers/test_noaa_rtofs.py
@@ -1,11 +1,10 @@
 """Tests for the NOAA RTOFS normalizer"""
 import unittest
-from collections import OrderedDict
+import unittest.mock as mock
 from datetime import datetime
 from dateutil.tz import tzutc
 
 import metanorm.normalizers as normalizers
-from .data import DATASET_PARAMETERS
 from metanorm.errors import MetadataNormalizationError
 
 
@@ -120,25 +119,26 @@ class NOAARTOFSMetadataNormalizerTestCase(unittest.TestCase):
         with self.assertRaises(MetadataNormalizationError):
             self.normalizer.get_time_coverage_end({})
 
-    def test_platform(self):
-        """platform from NOAARTOFSMetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_platform({}),
-            OrderedDict([('Category', 'Models/Analyses'),
-                         ('Series_Entity', ''),
-                         ('Short_Name', 'OPERATIONAL MODELS'),
-                         ('Long_Name', '')]))
+    def test_gcmd_platform(self):
+        """Test getting the platform"""
+        with mock.patch('metanorm.utils.get_gcmd_platform') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_platform({}),
+                mock_get_gcmd_method.return_value)
 
-    def test_instrument(self):
-        """instrument from NOAARTOFSMetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_instrument({}),
-            OrderedDict([('Category', 'In Situ/Laboratory Instruments'),
-                         ('Class', 'Data Analysis'),
-                         ('Type', 'Environmental Modeling'),
-                         ('Subtype', ''),
-                         ('Short_Name', 'Computer'),
-                         ('Long_Name', 'Computer')]))
+    def test_gcmd_instrument(self):
+        """Test getting the instrument"""
+        with mock.patch('metanorm.utils.get_gcmd_instrument') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_instrument({}),
+                mock_get_gcmd_method.return_value)
+
+    def test_gcmd_provider(self):
+        """Test getting the provider"""
+        with mock.patch('metanorm.utils.get_gcmd_provider') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_provider({}),
+                mock_get_gcmd_method.return_value)
 
     def test_location_geometry_global(self):
         """Should return the proper geometry"""
@@ -192,67 +192,68 @@ class NOAARTOFSMetadataNormalizerTestCase(unittest.TestCase):
         with self.assertRaises(MetadataNormalizationError):
             self.normalizer.get_location_geometry({})
 
-    def test_provider(self):
-        """provider from NOAARTOFSMetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_provider({}),
-            OrderedDict([
-                ('Bucket_Level0', 'GOVERNMENT AGENCIES-U.S. FEDERAL AGENCIES'),
-                ('Bucket_Level1', 'DOC'),
-                ('Bucket_Level2', 'NOAA'),
-                ('Bucket_Level3', ''),
-                ('Short_Name', 'DOC/NOAA/NWS/NCEP'),
-                ('Long_Name',
-                 'National Centers for Environmental Prediction, National Weather Service, NOAA, '
-                 'U.S. Department of Commerce'),
-                ('Data_Center_URL', 'http://www.ncep.noaa.gov/')]))
-
     def test_dataset_parameters_rtofs_2ds_diag(self):
         """Should return the proper dataset parameters"""
         attributes = {'url': 'ftp://ftpprd.ncep.noaa.gov/pub/data/nccf/com/rtofs/prod/'
                              'rtofs.20210518/rtofs_glo_2ds_f063_diag.nc'}
-        self.assertListEqual(self.normalizer.get_dataset_parameters(attributes), [
-            DATASET_PARAMETERS['sea_surface_height_above_geoid'],
-            DATASET_PARAMETERS['barotropic_eastward_sea_water_velocity'],
-            DATASET_PARAMETERS['barotropic_northward_sea_water_velocity'],
-            DATASET_PARAMETERS['surface_boundary_layer_thickness'],
-            DATASET_PARAMETERS['ocean_mixed_layer_thickness'],
-        ])
+        with mock.patch('metanorm.utils.create_parameter_list') as mock_utils_method:
+            self.assertEqual(
+                self.normalizer.get_dataset_parameters(attributes),
+                mock_utils_method.return_value)
+            mock_utils_method.assert_called_with([
+                'sea_surface_height_above_geoid',
+                'barotropic_eastward_sea_water_velocity',
+                'barotropic_northward_sea_water_velocity',
+                'surface_boundary_layer_thickness',
+                'ocean_mixed_layer_thickness',
+            ])
 
     def test_dataset_parameters_rtofs_2ds_prog(self):
         """Should return the proper dataset parameters"""
         attributes = {'url': 'ftp://ftpprd.ncep.noaa.gov/pub/data/nccf/com/rtofs/prod/'
                              'rtofs.20210518/rtofs_glo_2ds_f062_prog.nc'}
-        self.assertListEqual(self.normalizer.get_dataset_parameters(attributes), [
-            DATASET_PARAMETERS['eastward_sea_water_velocity'],
-            DATASET_PARAMETERS['northward_sea_water_velocity'],
-            DATASET_PARAMETERS['sea_surface_temperature'],
-            DATASET_PARAMETERS['sea_surface_salinity'],
-            DATASET_PARAMETERS['sea_water_potential_density'],
-        ])
+        with mock.patch('metanorm.utils.create_parameter_list') as mock_utils_method:
+            self.assertEqual(
+                self.normalizer.get_dataset_parameters(attributes),
+                mock_utils_method.return_value)
+            mock_utils_method.assert_called_with([
+                'eastward_sea_water_velocity',
+                'northward_sea_water_velocity',
+                'sea_surface_temperature',
+                'sea_surface_salinity',
+                'sea_water_potential_density',
+            ])
 
     def test_dataset_parameters_rtofs_2ds_ice(self):
         """Should return the proper dataset parameters"""
         attributes = {'url': 'ftp://ftpprd.ncep.noaa.gov/pub/data/nccf/com/rtofs/prod/'
                              'rtofs.20210518/rtofs_glo_2ds_f062_ice.nc'}
-        self.assertListEqual(self.normalizer.get_dataset_parameters(attributes), [
-            DATASET_PARAMETERS['ice_coverage'],
-            DATASET_PARAMETERS['ice_temperature'],
-            DATASET_PARAMETERS['ice_thickness'],
-            DATASET_PARAMETERS['ice_uvelocity'],
-            DATASET_PARAMETERS['icd_vvelocity'],
-        ])
+        with mock.patch('metanorm.utils.create_parameter_list') as mock_utils_method:
+            self.assertEqual(
+                self.normalizer.get_dataset_parameters(attributes),
+                mock_utils_method.return_value)
+            mock_utils_method.assert_called_with([
+                'ice_coverage',
+                'ice_temperature',
+                'ice_thickness',
+                'ice_uvelocity',
+                'icd_vvelocity',
+            ])
 
     def test_dataset_parameters_rtofs_3dz(self):
         """Should return the proper dataset parameters"""
         attributes = {'url': 'ftp://ftpprd.ncep.noaa.gov/pub/data/nccf/com/rtofs/prod/'
                              'rtofs.20210518/rtofs_glo_3dz_f024_daily_3zsio.nc'}
-        self.assertListEqual(self.normalizer.get_dataset_parameters(attributes), [
-            DATASET_PARAMETERS['eastward_sea_water_velocity'],
-            DATASET_PARAMETERS['northward_sea_water_velocity'],
-            DATASET_PARAMETERS['sea_surface_temperature'],
-            DATASET_PARAMETERS['sea_surface_salinity'],
-        ])
+        with mock.patch('metanorm.utils.create_parameter_list') as mock_utils_method:
+            self.assertEqual(
+                self.normalizer.get_dataset_parameters(attributes),
+                mock_utils_method.return_value)
+            mock_utils_method.assert_called_with([
+                'eastward_sea_water_velocity',
+                'northward_sea_water_velocity',
+                'sea_surface_temperature',
+                'sea_surface_salinity',
+            ])
 
     def test_dataset_parameters_missing_attribute(self):
         """An exception must be raised if the attribute is missing"""

--- a/tests/normalizers/test_podaac.py
+++ b/tests/normalizers/test_podaac.py
@@ -2,7 +2,6 @@
 
 import unittest
 import unittest.mock as mock
-from collections import OrderedDict
 from datetime import datetime, timezone
 
 import metanorm.normalizers as normalizers
@@ -119,11 +118,12 @@ class PODAACMetadataNormalizerTestCase(unittest.TestCase):
         with self.assertRaises(MetadataNormalizationError):
             self.normalizer.get_time_coverage_end({})
 
-    def test_get_platform(self):
+    def test_gcmd_platform(self):
         """Test getting the platform"""
-        with mock.patch('metanorm.utils.get_gcmd_platform') as mock_get_platform:
-            mock_get_platform.side_effect = lambda p: {'SENTINEL-1A': 'foo'}[p]
-            self.assertEqual(self.normalizer.get_platform({'platform': 'SENTINEL-1A'}), 'foo')
+        with mock.patch('metanorm.utils.get_gcmd_platform') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_platform({'platform': 'SENTINEL-1A'}),
+                mock_get_gcmd_method.return_value)
 
     def test_missing_platform(self):
         """A MetadataNormalizationError must be raised when the
@@ -132,11 +132,12 @@ class PODAACMetadataNormalizerTestCase(unittest.TestCase):
         with self.assertRaises(MetadataNormalizationError):
             self.normalizer.get_platform({})
 
-    def test_get_instrument(self):
+    def test_gcmd_instrument(self):
         """Test getting the instrument"""
-        with mock.patch('metanorm.utils.get_gcmd_instrument') as mock_get_instrument:
-            mock_get_instrument.side_effect = lambda p: {'VIIRS': 'foo'}[p]
-            self.assertEqual(self.normalizer.get_instrument({'sensor': 'VIIRS'}), 'foo')
+        with mock.patch('metanorm.utils.get_gcmd_instrument') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_instrument({'sensor': 'VIIRS'}),
+                mock_get_gcmd_method.return_value)
 
     def test_missing_sensor(self):
         """A MetadataNormalizationError must be raised when the
@@ -191,19 +192,20 @@ class PODAACMetadataNormalizerTestCase(unittest.TestCase):
             '-148.262 60.4, '
             '-147.443 25.982, '
             '-177.157 21.48, '
-            '-180 25.71789582937487, '
+            '-180 25.717895829374868, '
             '-180 55.60946639437804, '
             '-148.262 60.4)), '
-            '((180 25.71789582937487, '
+            '((180 25.717895829374868, '
             '161.791 52.861, '
             '180 55.60946639437804, '
-            '180 25.71789582937487)))')
+            '180 25.717895829374868)))')
 
     def test_get_location_geometry_from_geospatial_bounds_split_multipolygon(self):
         """Test getting the location geometry from the
         geospatial_bounds attribute with a multipolygon crossing the
         IDL
         """
+        self.maxDiff = None
         geometry = ('MULTIPOLYGON('
             '((-188.525390625 60.37042901631506,'
             '-165.14648437500003 56.46249048388978,'
@@ -227,32 +229,32 @@ class PODAACMetadataNormalizerTestCase(unittest.TestCase):
             }),
             'MULTIPOLYGON ('
             '((171.474609375 60.37042901631506, '
-            '180 58.94535368682163, '
+            '180 58.945353686821626, '
             '180 57.89199918002712, '
             '171.474609375 60.37042901631506)), '
-            '((-180 58.94535368682163, '
-            '-165.146484375 56.46249048388978, '
-            '-180 51.10473353644537, '
+            '((-180 58.945353686821626, '
+            '-165.14648437500003 56.46249048388978, '
+            '-180 51.104733536445366, '
             '-180 52.38008427459071, '
-            '-173.2324218750001 55.92458580482949, '
-            '-180 57.89199918002712, -180 58.94535368682163)), '
-            '((180 51.10473353644537, '
-            '172.177734375 48.2831928954835, '
+            '-173.23242187500006 55.92458580482949, '
+            '-180 57.89199918002712, -180 58.945353686821626)), '
+            '((180 51.104733536445366, '
+            '172.17773437499997 48.283192895483495, '
             '180 52.38008427459071, '
-            '180 51.10473353644537)), '
-            '((175.166015625 57.98480801923986, '
-            '180 56.80657678152991, '
+            '180 51.104733536445366)), '
+            '((175.166015625 57.984808019239864, '
+            '180 56.806576781529905, '
             '180 54.85557165879511, '
             '174.7265625 52.48278022207825, '
-            '175.166015625 57.98480801923986), '
-            '(178.154296875 56.63206372054478, '
-            '175.693359375 55.67758441108953, '
-            '178.505859375 54.80068486732236, '
-            '178.154296875 56.63206372054478)), '
-            '((-180 56.80657678152991, '
-            '-177.1875 56.12106042504411, '
+            '175.166015625 57.984808019239864), '
+            '(178.15429687500003 56.63206372054478, '
+            '175.693359375 55.677584411089526, '
+            '178.50585937500003 54.80068486732236, '
+            '178.15429687500003 56.63206372054478)), '
+            '((-180 56.806576781529905, '
+            '-177.18749999999997 56.12106042504411, '
             '-180 54.85557165879511, '
-            '-180 56.80657678152991)))')
+            '-180 56.806576781529905)))')
 
     def test_get_location_geometry_split_global_coverage(self):
         """Test getting the location geometry from a global bounding
@@ -327,19 +329,9 @@ class PODAACMetadataNormalizerTestCase(unittest.TestCase):
         with self.assertRaises(MetadataNormalizationError):
             self.normalizer.get_location_geometry({'northernmost_latitude': '9'})
 
-    def test_get_provider(self):
+    def test_gcmd_provider(self):
         """Test getting the provider"""
-        self.assertDictEqual(
-            self.normalizer.get_provider({}),
-            OrderedDict([
-                ('Bucket_Level0', 'GOVERNMENT AGENCIES-U.S. FEDERAL AGENCIES'),
-                ('Bucket_Level1', 'NASA'),
-                ('Bucket_Level2', ''),
-                ('Bucket_Level3', ''),
-                ('Short_Name', 'NASA/JPL/PODAAC'),
-                ('Long_Name',
-                 'Physical Oceanography Distributed Active Archive Center, Jet Propulsion '
-                 'Laboratory, NASA'),
-                ('Data_Center_URL', 'https://podaac.jpl.nasa.gov/')
-            ])
-        )
+        with mock.patch('metanorm.utils.get_gcmd_provider') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_provider({}),
+                mock_get_gcmd_method.return_value)

--- a/tests/normalizers/test_radarsat2_csv.py
+++ b/tests/normalizers/test_radarsat2_csv.py
@@ -1,7 +1,7 @@
 """Tests for the Radarsat 2 CSV normalizer"""
 import datetime as dt
 import unittest
-from collections import OrderedDict
+import unittest.mock as mock
 
 from dateutil.tz import tzutc
 
@@ -101,25 +101,26 @@ class Radarsat2CSVNormalizerTests(unittest.TestCase):
         with self.assertRaises(MetadataNormalizationError):
             self.normalizer.get_time_coverage_end({})
 
-    def test_get_platform(self):
-        """ shall return radarsat-2 """
-        self.assertEqual(
-            self.normalizer.get_platform(self.metadata),
-            OrderedDict([('Category', 'Earth Observation Satellites'),
-             ('Series_Entity', 'RADARSAT'),
-             ('Short_Name', 'RADARSAT-2'),
-             ('Long_Name', '')]))
+    def test_gcmd_platform(self):
+        """Test getting the platform"""
+        with mock.patch('metanorm.utils.get_gcmd_platform') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_platform({}),
+                mock_get_gcmd_method.return_value)
 
-    def test_get_instrument(self):
-        """ shall return c-sar """
-        self.assertEqual(
-            self.normalizer.get_instrument(self.metadata),
-            OrderedDict([('Category', 'Earth Remote Sensing Instruments'),
-                         ('Class', 'Active Remote Sensing'),
-                         ('Type', 'Imaging Radars'),
-                         ('Subtype', ''),
-                         ('Short_Name', 'C-SAR'),
-                         ('Long_Name', 'C-Band Synthetic Aperture Radar')]))
+    def test_gcmd_instrument(self):
+        """Test getting the instrument"""
+        with mock.patch('metanorm.utils.get_gcmd_instrument') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_instrument({}),
+                mock_get_gcmd_method.return_value)
+
+    def test_gcmd_provider(self):
+        """Test getting the provider"""
+        with mock.patch('metanorm.utils.get_gcmd_provider') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_provider({}),
+                mock_get_gcmd_method.return_value)
 
     def test_get_location_geometry(self):
         """ shall return POLYGON """
@@ -135,26 +136,9 @@ class Radarsat2CSVNormalizerTests(unittest.TestCase):
         with self.assertRaises(MetadataNormalizationError):
             self.normalizer.get_location_geometry({})
 
-    def test_get_provider(self):
-        """ shall return csa """
-        self.assertEqual(
-            self.normalizer.get_provider(self.metadata),
-            OrderedDict([('Bucket_Level0', 'COMMERCIAL'),
-                         ('Bucket_Level1', ''),
-                         ('Bucket_Level2', ''),
-                         ('Bucket_Level3', ''),
-                         ('Short_Name', 'CSA'),
-                         ('Long_Name', 'Cambridge Scientific Abstracts'),
-                         ('Data_Center_URL', 'http://www.csa.com/')]))
-
-    def test_get_parameters(self):
-        """ shall return sigma0 wkv """
-        self.assertCountEqual(
-            self.normalizer.get_dataset_parameters(self.metadata), [
-                OrderedDict([
-                    ('standard_name', 'surface_backwards_scattering_coefficient_of_radar_wave'),
-                    ('long_name', 'Normalized Radar Cross Section'),
-                    ('short_name', 'sigma0'),
-                    ('units', 'm/m'),
-                    ('minmax', '0 0.1'),
-                    ('colormap', 'gray')])])
+    def test_dataset_parameters(self):
+        """dataset_parameters from CEDAESACCIMetadataNormalizer """
+        with mock.patch('metanorm.utils.create_parameter_list') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_dataset_parameters({}),
+                mock_get_gcmd_method.return_value)

--- a/tests/normalizers/test_remss_gmi.py
+++ b/tests/normalizers/test_remss_gmi.py
@@ -1,11 +1,10 @@
 """Tests for the REMSS GMI normalizer"""
 import unittest
-from collections import OrderedDict
+import unittest.mock as mock
 from datetime import datetime
 from dateutil.tz import tzutc
 
 import metanorm.normalizers as normalizers
-from .data import DATASET_PARAMETERS
 from metanorm.errors import MetadataNormalizationError
 
 
@@ -116,25 +115,26 @@ class REMSSGMIMetadataNormalizerTestCase(unittest.TestCase):
         with self.assertRaises(MetadataNormalizationError):
             self.normalizer.get_time_coverage_end({})
 
-    def test_platform(self):
-        """platform from REMSSGMIMetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_platform({}),
-            OrderedDict([('Category', 'Earth Observation Satellites'),
-                         ('Series_Entity', ''),
-                         ('Short_Name', 'GPM'),
-                         ('Long_Name', 'Global Precipitation Measurement')]))
+    def test_gcmd_platform(self):
+        """Test getting the platform"""
+        with mock.patch('metanorm.utils.get_gcmd_platform') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_platform({}),
+                mock_get_gcmd_method.return_value)
 
-    def test_instrument(self):
-        """instrument from REMSSGMIMetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_instrument({}),
-            OrderedDict([('Category', 'Earth Remote Sensing Instruments'),
-                         ('Class', 'Passive Remote Sensing'),
-                         ('Type', 'Spectrometers/Radiometers'),
-                         ('Subtype', 'Imaging Spectrometers/Radiometers'),
-                         ('Short_Name', 'GMI'),
-                         ('Long_Name', 'Global Precipitation Measurement Microwave Imager')]))
+    def test_gcmd_instrument(self):
+        """Test getting the instrument"""
+        with mock.patch('metanorm.utils.get_gcmd_instrument') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_instrument({}),
+                mock_get_gcmd_method.return_value)
+
+    def test_gcmd_provider(self):
+        """Test getting the provider"""
+        with mock.patch('metanorm.utils.get_gcmd_provider') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_provider({}),
+                mock_get_gcmd_method.return_value)
 
     def test_location_geometry(self):
         """geometry from REMSSGMIMetadataNormalizer """
@@ -142,23 +142,9 @@ class REMSSGMIMetadataNormalizerTestCase(unittest.TestCase):
             self.normalizer.get_location_geometry({}),
             'POLYGON((-180 -90, -180 90, 180 90, 180 -90, -180 -90))')
 
-    def test_provider(self):
-        """provider from REMSSGMIMetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_provider({}),
-            OrderedDict([('Bucket_Level0', 'COMMERCIAL'),
-                         ('Bucket_Level1', ''),
-                         ('Bucket_Level2', ''),
-                         ('Bucket_Level3', ''),
-                         ('Short_Name', 'RSS'),
-                         ('Long_Name', 'Remote Sensing Systems'),
-                         ('Data_Center_URL', 'http://www.remss.com/')]))
-
     def test_dataset_parameters(self):
-        """dataset_parameters from REMSSGMIMetadataNormalizer """
-        self.assertEqual(self.normalizer.get_dataset_parameters({}), [
-            DATASET_PARAMETERS['wind_speed'],
-            DATASET_PARAMETERS['atmosphere_mass_content_of_water_vapor'],
-            DATASET_PARAMETERS['atmosphere_mass_content_of_cloud_liquid_water'],
-            DATASET_PARAMETERS['rainfall_rate'],
-        ])
+        """dataset_parameters from CEDAESACCIMetadataNormalizer """
+        with mock.patch('metanorm.utils.create_parameter_list') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_dataset_parameters({}),
+                mock_get_gcmd_method.return_value)

--- a/tests/normalizers/test_scihub_odata.py
+++ b/tests/normalizers/test_scihub_odata.py
@@ -1,5 +1,6 @@
 """Tests for the ACDD metadata normalizer"""
 import unittest
+import unittest.mock as mock
 from collections import OrderedDict
 from datetime import datetime
 
@@ -160,151 +161,25 @@ class ScihubODataMetadataNormalizerTestCase(unittest.TestCase):
 
     def test_gcmd_platform(self):
         """gcmd_platform from ScihubODataMetadataNormalizer"""
-        attributes = {'Satellite name': 'SENTINEL-1', 'Satellite number': 'B'}
-
-        self.assertEqual(
-            self.normalizer.get_platform(attributes),
-            OrderedDict([('Category', 'Earth Observation Satellites'),
-                         ('Series_Entity', 'Sentinel-1'),
-                         ('Short_Name', 'Sentinel-1B'),
-                         ('Long_Name', 'Sentinel-1B')])
-        )
-
-    def test_non_gcmd_platform(self):
-        """Non-GCMD platform from ScihubODataMetadataNormalizer"""
-        attributes = {'Satellite name': 'TEST', 'Satellite number': 'A'}
-
-        self.assertEqual(
-            self.normalizer.get_platform(attributes),
-            OrderedDict([
-                ('Category', 'Unknown'),
-                ('Series_Entity', 'Unknown'),
-                ('Short_Name', 'TESTA'),
-                ('Long_Name', 'TESTA')
-            ])
-        )
-
-    def test_non_gcmd_platform_long_name(self):
-        """
-        Non-GCMD platform from ScihubODataMetadataNormalizer, with a name longer than 250 characters
-        """
-        attributes = {
-            'Satellite name': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do ei' +
-                              'usmod tempor incididunt ut labore et dolore magna aliqua. Bibendum' +
-                              ' neque egest as congue quisque egestas diam in. Eget magna ferment' +
-                              'um iaculis eu non diam phasellus vestibulum lorvgem. Tempor commodo',
-            'Satellite number': 'A'
-        }
-
-        self.assertEqual(
-            self.normalizer.get_platform(attributes),
-            OrderedDict([
-                ('Category', 'Unknown'),
-                ('Series_Entity', 'Unknown'),
-                ('Short_Name', attributes['Satellite name'][:100]),
-                ('Long_Name', attributes['Satellite name'][:250])
-            ])
-        )
+        with mock.patch('metanorm.utils.get_gcmd_platform') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_platform({'Satellite name': 'foo', 'Satellite number': 'bar'}),
+                mock_get_gcmd_method.return_value)
 
     def test_platform_missing_attribute(self):
         """An exception must be raised if the attribute is missing"""
         with self.assertRaises(MetadataNormalizationError):
             self.normalizer.get_platform({})
 
-    def test_gcmd_instrument_from_get(self):
+    def test_gcmd_instrument(self):
         """
         GCMD instrument from ScihubODataMetadataNormalizer which is found using
         `pythesint.get_gcmd_instrument()`
         """
-        self.assertEqual(
-            self.normalizer.get_instrument({'Instrument': 'MODIS'}),
-            OrderedDict([('Category', 'Earth Remote Sensing Instruments'),
-                         ('Class', 'Passive Remote Sensing'),
-                         ('Type', 'Spectrometers/Radiometers'),
-                         ('Subtype', 'Imaging Spectrometers/Radiometers'),
-                         ('Short_Name', 'MODIS'),
-                         ('Long_Name', 'Moderate-Resolution Imaging Spectroradiometer')]))
-
-    def test_gcmd_instrument_from_search(self):
-        """
-        GCMD instrument from ScihubODataMetadataNormalizer which is found using
-        `pythesint.search_gcmd_instrument_list()`
-        """
-        self.assertEqual(
-            self.normalizer.get_instrument({'Instrument': 'SRAL'}),
-            OrderedDict([('Category', 'Earth Remote Sensing Instruments'),
-                         ('Class', 'Active Remote Sensing'),
-                         ('Type', 'Altimeters'),
-                         ('Subtype', 'Radar Altimeters'),
-                         ('Short_Name', 'Sentinel-3 SRAL'),
-                         ('Long_Name', 'Sentinel-3 SAR Radar Altimeter')]))
-
-    def test_gcmd_instrument_from_restricted_search(self):
-        """
-        GCMD instrument from ScihubODataMetadataNormalizer which is found using
-        `pythesint.search_gcmd_instrument_list()` and restricting the search with an
-        additional keyword
-        """
-        self.assertEqual(
-            self.normalizer.get_instrument({
-                'Satellite name': 'SENTINEL-2',
-                'Instrument': 'MSI'}),
-            OrderedDict([('Category', 'Earth Remote Sensing Instruments'),
-                         ('Class', 'Passive Remote Sensing'),
-                         ('Type', 'Spectrometers/Radiometers'),
-                         ('Subtype', 'Imaging Spectrometers/Radiometers'),
-                         ('Short_Name', 'Sentinel-2 MSI'),
-                         ('Long_Name', 'Sentinel-2 Multispectral Imager')]))
-
-    def test_c_sar_instrument(self):
-        """Special case for C-SAR GCMD instrument from ScihubODataMetadataNormalizer"""
-        self.assertEqual(
-            self.normalizer.get_instrument(
-                {'Satellite name': 'SENTINEL-1','Instrument': 'SAR-C SAR'}),
-            OrderedDict([('Category', 'Earth Remote Sensing Instruments'),
-                         ('Class', 'Active Remote Sensing'),
-                         ('Type', 'Imaging Radars'),
-                         ('Subtype', ''),
-                         ('Short_Name', 'SENTINEL-1 C-SAR'),
-                         ('Long_Name', '')]))
-
-    def test_non_gcmd_instrument(self):
-        """Non-GCMD instrument from ScihubODataMetadataNormalizer"""
-        self.assertEqual(
-            self.normalizer.get_instrument({'Instrument': 'TEST'}),
-            OrderedDict([
-                ('Category', 'Unknown'),
-                ('Class', 'Unknown'),
-                ('Type', 'Unknown'),
-                ('Subtype', 'Unknown'),
-                ('Short_Name', 'TEST'),
-                ('Long_Name', 'TEST')
-            ])
-        )
-
-    def test_non_gcmd_instrument_long_name(self):
-        """Non-GCMD instrument from ScihubODataMetadataNormalizer,
-        with a name longer than 200 characters
-        """
-        attributes = {
-            'Instrument':
-                'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod ' +
-                'tempor incididunt ut labore et dolore magna aliqua. Bibendum neque egest' +
-                'as congue quisque egestas diam in. Eget magna fermentum iaculis eu non d' +
-                'iam phasellus vestibulum lorvgem. Tempor commodo.'
-        }
-
-        self.assertEqual(
-            self.normalizer.get_instrument(attributes),
-            OrderedDict([
-                ('Category', 'Unknown'),
-                ('Class', 'Unknown'),
-                ('Type', 'Unknown'),
-                ('Subtype', 'Unknown'),
-                ('Short_Name', attributes['Instrument'][:60]),
-                ('Long_Name', attributes['Instrument'][:200])
-            ])
-        )
+        with mock.patch('metanorm.utils.get_gcmd_instrument') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_instrument({'Satellite name': 'foo', 'Instrument': 'bar'}),
+                mock_get_gcmd_method.return_value)
 
     def test_instrument_missing_attribute(self):
         """An exception must be raised if the attribute is missing"""
@@ -338,51 +213,26 @@ class ScihubODataMetadataNormalizerTestCase(unittest.TestCase):
         with self.assertRaises(MetadataNormalizationError):
             self.normalizer.get_location_geometry({})
 
-    def test_gcmd_provider_from_url(self):
+    def test_gcmd_provider(self):
         """GCMD provider from ScihubODataMetadataNormalizer"""
-        expected_provider = OrderedDict([
-            ('Bucket_Level0', 'MULTINATIONAL ORGANIZATIONS'),
-            ('Bucket_Level1', ''),
-            ('Bucket_Level2', ''),
-            ('Bucket_Level3', ''),
-            ('Short_Name', 'ESA/EO'),
-            ('Long_Name', 'Observing the Earth, European Space Agency'),
-            ('Data_Center_URL', 'http://www.esa.int/esaEO/')])
-
-        attributes = {'url': 'https://scihub.copernicus.eu'}
-        self.assertEqual(
-            self.normalizer.get_provider(attributes),
-            expected_provider
-        )
-
-        attributes = {'url': 'https://apihub.copernicus.eu'}
-        self.assertEqual(
-            self.normalizer.get_provider(attributes),
-            expected_provider
-        )
+        with mock.patch('metanorm.utils.get_gcmd_provider') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_provider({}),
+                mock_get_gcmd_method.return_value)
 
     def test_dataset_parameters_sentinel1(self):
         """Test getting the dataset parameters for Sentinel 1 datasets
         """
-        self.assertListEqual(
-            self.normalizer.get_dataset_parameters({
-                'Identifier': 'S1B_IW_GRDH_1SDV_20210916T103902_20210916T103927_028722_036D80_C8D0'
-            }),
-            [
-                OrderedDict([
-                    ('standard_name', 'surface_backwards_scattering_coefficient_of_radar_wave'),
-                    ('canonical_units', '1'),
-                    ('definition', 'The scattering/absorption/attenuation coefficient is assumed to'
-                                   ' be an integral over all wavelengths, unless a coordinate of '
-                                   'radiation_wavelength is included to specify the wavelength. '
-                                   'Scattering of radiation is its deflection from its incident '
-                                   'path without loss of energy. Backwards scattering refers to the'
-                                   ' sum of scattering into all backward angles i.e. '
-                                   'scattering_angle exceeding pi/2 radians. A scattering_angle '
-                                   'should not be specified with this quantity.')
-                ])
-            ]
-        )
+        with mock.patch('metanorm.utils.create_parameter_list') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_dataset_parameters({
+                    'Identifier': 'S1B_IW_GRDH_1SDV_20210916T103902_20210916T103927_028722_036D80_'
+                                  'C8D0',
+                }),
+                mock_get_gcmd_method.return_value)
+            mock_get_gcmd_method.assert_called_with([
+                'surface_backwards_scattering_coefficient_of_radar_wave'
+            ])
 
     def test_unknown_dataset_parameters(self):
         """An empty list should be returned if no parameter is found"""


### PR DESCRIPTION
Check out #128 first!

Resolves #125 
Add support for TOPAZ products from CMEMS and met.no.
Some github actions versions had to be updated.

The unit tests will pass once #128  is merged 