### PR TITLE
Refactor unit tests

### DIFF
--- a/.github/workflows/tests_and_build.yml
+++ b/.github/workflows/tests_and_build.yml
@@ -2,7 +2,7 @@
 name: "Unit tests and builds"
 on: push
 env:
-  BASE_IMAGE_NAME: "${{ secrets.DOCKER_ORG }}/nansat_base:2.0.3-slim"
+  BASE_IMAGE_NAME: "${{ secrets.DOCKER_ORG }}/nansat_base:2.1.3-slim"
   TESTING_IMAGE_NAME: metanorm_tests
 jobs:
   tests_build:

--- a/docker/Dockerfile_tests
+++ b/docker/Dockerfile_tests
@@ -6,24 +6,6 @@ RUN pip install --no-cache-dir \
     setuptools \
     wheel
 
-RUN python -c 'import pythesint; pythesint.update_all_vocabularies( \
-{ \
-    "gcmd_instrument": "9.1.5", \
-    "gcmd_science_keyword": "9.1.5", \
-    "gcmd_provider": "9.1.5", \
-    "gcmd_platform": "9.1.5", \
-    "gcmd_location": "9.1.5", \
-    "gcmd_horizontalresolutionrange": "9.1.5", \
-    "gcmd_verticalresolutionrange": "9.1.5", \
-    "gcmd_temporalresolutionrange": "9.1.5", \
-    "gcmd_project": "9.1.5", \
-    "gcmd_rucontenttype": "9.1.5", \
-    "mmd_access_constraints": "v3.2", \
-    "mmd_activity_type": "v3.2", \
-    "mmd_areas": "v3.2", \
-    "mmd_operstatus": "v3.2", \
-    "mmd_platform_type": "v3.2", \
-    "mmd_use_constraint_type": "v3.2", \
-})'
+RUN python -c 'import pythesint; pythesint.update_all_vocabularies()'
 
 WORKDIR /src

--- a/metanorm/normalizers/geospaas/cmems.py
+++ b/metanorm/normalizers/geospaas/cmems.py
@@ -414,7 +414,6 @@ class CMEMS002003MetadataNormalizer(CMEMSMetadataNormalizer):
     def get_location_geometry(self, raw_metadata):
         return 'POLYGON((-180 53, -180 90, 180 90, 180 53, -180 53))'
 
-    @utils.raises(KeyError)
     def get_dataset_parameters(self, raw_metadata):
         return utils.create_parameter_list([
             'latitude',

--- a/metanorm/normalizers/geospaas/cmems_in_situ_tac.py
+++ b/metanorm/normalizers/geospaas/cmems_in_situ_tac.py
@@ -80,10 +80,10 @@ class CMEMSInSituTACMetadataNormalizer(GeoSPaaSMetadataNormalizer):
         return dateutil.parser.parse(raw_metadata['time_coverage_end'])
 
     def get_platform(self, raw_metadata):
-        return pti.get_gcmd_platform('In Situ Ocean-based Platforms')
+        return utils.get_gcmd_platform('In Situ Ocean-based Platforms')
 
     def get_instrument(self, raw_metadata):
-        return pti.get_gcmd_instrument('In Situ/Laboratory Instruments')
+        return utils.get_gcmd_instrument('In Situ/Laboratory Instruments')
 
     @utils.raises(KeyError)
     def get_location_geometry(self, raw_metadata):

--- a/metanorm/normalizers/geospaas/cpom.py
+++ b/metanorm/normalizers/geospaas/cpom.py
@@ -39,7 +39,7 @@ class CPOMAltimetryMetadataNormalizer(GeoSPaaSMetadataNormalizer):
         return raw_metadata.get('geometry', '')
 
     def get_provider(self, raw_metadata):
-        return pti.get_gcmd_provider('UC-LONDON/CPOM')
+        return utils.get_gcmd_provider(['UC-LONDON/CPOM'])
 
     def get_dataset_parameters(self, raw_metadata):
-        return [pti.get_wkv_variable('sea_surface_height_above_sea_level')]
+        return utils.create_parameter_list(['sea_surface_height_above_sea_level'])

--- a/metanorm/normalizers/geospaas/nextsim.py
+++ b/metanorm/normalizers/geospaas/nextsim.py
@@ -61,10 +61,10 @@ class NextsimMetadataNormalizer(GeoSPaaSMetadataNormalizer):
         return self.get_time_coverage_start(raw_metadata) + timedelta(days=1)
 
     def get_platform(self, raw_metadata):
-        return pti.get_gcmd_platform('OPERATIONAL MODELS')
+        return utils.get_gcmd_platform('OPERATIONAL MODELS')
 
     def get_instrument(self, raw_metadata):
-        return pti.get_gcmd_instrument('Computer')
+        return utils.get_gcmd_instrument('Computer')
 
     def get_location_geometry(self, raw_metadata):
         return utils.wkt_polygon_from_wgs84_limits('90', '62', '180', '-180')

--- a/metanorm/normalizers/geospaas/osisaf.py
+++ b/metanorm/normalizers/geospaas/osisaf.py
@@ -3,7 +3,6 @@
 import re
 
 import dateutil.parser
-import pythesint as pti
 from dateutil.tz import tzutc
 
 import metanorm.utils as utils
@@ -60,12 +59,12 @@ class OSISAFMetadataNormalizer(GeoSPaaSMetadataNormalizer):
             if ('_ice_conc' in raw_metadata['product_name']
                     or '_ice_type' in raw_metadata['product_name']
                     or '_ice_edge' in raw_metadata['product_name']):
-                return pti.get_gcmd_instrument('Imaging Spectrometers/Radiometers')
+                return utils.get_gcmd_instrument('Imaging Spectrometers/Radiometers')
             elif 'amsr2ice_conc' in raw_metadata['product_name']:
-                return pti.get_gcmd_instrument('AMSR2')
+                return utils.get_gcmd_instrument('AMSR2')
             elif '_mr_ice_drift' in raw_metadata['product_name']:
-                return pti.get_gcmd_instrument('AVHRR')
-        return pti.get_gcmd_instrument('Earth Remote Sensing Instruments')
+                return utils.get_gcmd_instrument('AVHRR')
+        return utils.get_gcmd_instrument('Earth Remote Sensing Instruments')
 
     @utils.raises(KeyError)
     def get_location_geometry(self, raw_metadata):

--- a/metanorm/normalizers/geospaas/radarsat2_csv.py
+++ b/metanorm/normalizers/geospaas/radarsat2_csv.py
@@ -36,10 +36,10 @@ class Radarsat2CSVMetadataNormalizer(GeoSPaaSMetadataNormalizer):
         return self.get_time_coverage_start(raw_metadata) + timedelta(minutes=5)
 
     def get_platform(self, raw_metadata):
-        return pti.get_gcmd_platform('RADARSAT-2')
+        return utils.get_gcmd_platform('RADARSAT-2')
 
     def get_instrument(self, raw_metadata):
-        return pti.get_gcmd_instrument('C-SAR')
+        return utils.get_gcmd_instrument('C-SAR')
 
     @utils.raises(KeyError)
     def get_location_geometry(self, raw_metadata):
@@ -50,7 +50,7 @@ class Radarsat2CSVMetadataNormalizer(GeoSPaaSMetadataNormalizer):
                 f"{footprint[8]} {footprint[9]}))")
 
     def get_provider(self, raw_metadata):
-        return pti.get_gcmd_provider('CSA')
+        return utils.get_gcmd_provider(['CSA'])
 
     def get_dataset_parameters(self, raw_metadata):
-        return [pti.get_wkv_variable('surface_backwards_scattering_coefficient_of_radar_wave')]
+        return utils.create_parameter_list('surface_backwards_scattering_coefficient_of_radar_wave')

--- a/metanorm/normalizers/geospaas/scihub_odata.py
+++ b/metanorm/normalizers/geospaas/scihub_odata.py
@@ -111,8 +111,8 @@ class ScihubODataMetadataNormalizer(GeoSPaaSMetadataNormalizer):
     def get_dataset_parameters(self, raw_metadata):
         """Returns known dataset parameters depending on the dataset's ID"""
         if self.SENTINEL1_ID_MATCHER.match(raw_metadata['Identifier']):
-            return [
-                utils.get_cf_or_wkv_standard_name(
-                    'surface_backwards_scattering_coefficient_of_radar_wave')]
+            return utils.create_parameter_list([
+                'surface_backwards_scattering_coefficient_of_radar_wave'
+            ])
         else:
             return []

--- a/metanorm/normalizers/geospaas/scihub_odata.py
+++ b/metanorm/normalizers/geospaas/scihub_odata.py
@@ -103,7 +103,6 @@ class ScihubODataMetadataNormalizer(GeoSPaaSMetadataNormalizer):
         """Returns a WKT string corresponding to the location of the dataset"""
         return raw_metadata['JTS footprint']
 
-    @utils.raises(KeyError)
     def get_provider(self, raw_metadata):
         """Returns a GCMD-like provider data structure"""
         return utils.get_gcmd_provider(['ESA/EO'])

--- a/metanorm/utils.py
+++ b/metanorm/utils.py
@@ -301,7 +301,7 @@ def translate_west_coordinates(multipolygon):
         return shapely.geometry.LinearRing(translate_point(point) for point in ring.coords)
 
     new_polygons = []
-    for polygon in multipolygon:
+    for polygon in multipolygon.geoms:
 
         exterior_ring = translate_ring(polygon.exterior)
 
@@ -335,7 +335,7 @@ def restore_west_coordinates(multipolygon):
         return shapely.geometry.LinearRing(restore_point(point, is_east) for point in ring.coords)
 
     new_polygons = []
-    for polygon in multipolygon:
+    for polygon in multipolygon.geoms:
         # Determine if this polygon is on the east or west side of the
         # IDL. It has been split already, so it is either east or west.
         # We find the first point which is not on the IDL and check

--- a/tests/normalizers/test_aviso.py
+++ b/tests/normalizers/test_aviso.py
@@ -2,7 +2,6 @@
 
 import unittest
 import unittest.mock as mock
-from collections import OrderedDict
 from datetime import datetime, timezone
 
 import metanorm.normalizers as normalizers
@@ -134,29 +133,26 @@ class AVISOAltimetryMetadataNormalizerTests(unittest.TestCase):
         with self.assertRaises(MetadataNormalizationError):
             self.normalizer.get_time_coverage_end({})
 
-    def test_get_platform(self):
+    def test_gcmd_platform(self):
         """Test getting the platform"""
-        self.assertDictEqual(
-            self.normalizer.get_platform({}),
-            OrderedDict([
-                ('Category', 'Earth Observation Satellites'),
-                ('Series_Entity', ''),
-                ('Short_Name', ''),
-                ('Long_Name', '')])
-        )
+        with mock.patch('metanorm.utils.get_gcmd_platform') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_platform({}),
+                mock_get_gcmd_method.return_value)
 
-    def test_get_instrument(self):
+    def test_gcmd_instrument(self):
         """Test getting the instrument"""
-        self.assertDictEqual(
-            self.normalizer.get_instrument({}),
-            OrderedDict([
-                ('Category', 'Earth Remote Sensing Instruments'),
-                ('Class', 'Active Remote Sensing'),
-                ('Type', 'Altimeters'),
-                ('Subtype', ''),
-                ('Short_Name', ''),
-                ('Long_Name', '')])
-        )
+        with mock.patch('metanorm.utils.get_gcmd_instrument') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_instrument({}),
+                mock_get_gcmd_method.return_value)
+
+    def test_gcmd_provider(self):
+        """Test getting the provider"""
+        with mock.patch('metanorm.utils.get_gcmd_provider') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_provider({}),
+                mock_get_gcmd_method.return_value)
 
     def test_get_location_geometry(self):
         """Test getting the geometry"""
@@ -168,17 +164,3 @@ class AVISOAltimetryMetadataNormalizerTests(unittest.TestCase):
         """
         self.assertEqual(self.normalizer.get_location_geometry({}), '')
 
-    def test_get_provider(self):
-        """Test getting the provider"""
-        self.assertDictEqual(
-            self.normalizer.get_provider({}),
-            OrderedDict([
-                ('Bucket_Level0', 'COMMERCIAL'),
-                ('Bucket_Level1', ''),
-                ('Bucket_Level2', ''),
-                ('Bucket_Level3', ''),
-                ('Short_Name', 'AVISO'),
-                ('Long_Name',
-                'Archiving, Validation and Interpretation of Satellite Oceanographic Data'),
-                ('Data_Center_URL', 'http://www.aviso.oceanobs.com/')])
-        )

--- a/tests/normalizers/test_ceda_esa_cci.py
+++ b/tests/normalizers/test_ceda_esa_cci.py
@@ -5,7 +5,6 @@ from datetime import datetime
 from dateutil.tz import tzutc
 
 import metanorm.normalizers as normalizers
-from .data import DATASET_PARAMETERS
 from metanorm.errors import MetadataNormalizationError
 
 
@@ -111,6 +110,7 @@ class CEDAESACCIMetadataNormalizerTestCase(unittest.TestCase):
 
     def test_dataset_parameters(self):
         """dataset_parameters from CEDAESACCIMetadataNormalizer """
-        self.assertEqual(self.normalizer.get_dataset_parameters({}), [
-            DATASET_PARAMETERS['sea_surface_temperature'],
-        ])
+        with mock.patch('metanorm.utils.create_parameter_list') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_dataset_parameters({}),
+                mock_get_gcmd_method.return_value)

--- a/tests/normalizers/test_ceda_esa_cci.py
+++ b/tests/normalizers/test_ceda_esa_cci.py
@@ -1,6 +1,6 @@
 """Tests for the ESA CCI normalizer"""
 import unittest
-from collections import OrderedDict
+import unittest.mock as mock
 from datetime import datetime
 from dateutil.tz import tzutc
 
@@ -82,43 +82,32 @@ class CEDAESACCIMetadataNormalizerTestCase(unittest.TestCase):
         with self.assertRaises(MetadataNormalizationError):
             self.normalizer.get_time_coverage_end({})
 
-    def test_platform(self):
-        """platform from CEDAESACCIMetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_platform({}),
-            OrderedDict([('Category', 'Earth Observation Satellites'),
-                         ('Series_Entity', ''),
-                         ('Short_Name', ''),
-                         ('Long_Name', '')]))
+    def test_gcmd_platform(self):
+        """Test getting the platform"""
+        with mock.patch('metanorm.utils.get_gcmd_platform') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_platform({}),
+                mock_get_gcmd_method.return_value)
 
-    def test_instrument(self):
-        """instrument from CEDAESACCIMetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_instrument({}),
-            OrderedDict([('Category', 'Earth Remote Sensing Instruments'),
-                         ('Class', 'Passive Remote Sensing'),
-                         ('Type', 'Spectrometers/Radiometers'),
-                         ('Subtype', 'Imaging Spectrometers/Radiometers'),
-                         ('Short_Name', ''),
-                         ('Long_Name', '')]))
+    def test_gcmd_instrument(self):
+        """Test getting the instrument"""
+        with mock.patch('metanorm.utils.get_gcmd_instrument') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_instrument({}),
+                mock_get_gcmd_method.return_value)
+
+    def test_gcmd_provider(self):
+        """Test getting the provider"""
+        with mock.patch('metanorm.utils.get_gcmd_provider') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_provider({}),
+                mock_get_gcmd_method.return_value)
 
     def test_location_geometry(self):
         """geometry from CEDAESACCIMetadataNormalizer """
         self.assertEqual(
             self.normalizer.get_location_geometry({}),
             'POLYGON((-180 -90, -180 90, 180 90, 180 -90, -180 -90))')
-
-    def test_provider(self):
-        """provider from CEDAESACCIMetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_provider({}),
-            OrderedDict([('Bucket_Level0', 'MULTINATIONAL ORGANIZATIONS'),
-                         ('Bucket_Level1', ''),
-                         ('Bucket_Level2', ''),
-                         ('Bucket_Level3', ''),
-                         ('Short_Name', 'ESA/CCI'),
-                         ('Long_Name', 'Climate Change Initiative, European Space Agency'),
-                         ('Data_Center_URL', '')]))
 
     def test_dataset_parameters(self):
         """dataset_parameters from CEDAESACCIMetadataNormalizer """

--- a/tests/normalizers/test_cmems.py
+++ b/tests/normalizers/test_cmems.py
@@ -7,8 +7,27 @@ from collections import OrderedDict
 from datetime import datetime, timezone
 
 import metanorm.normalizers as normalizers
-from .data import DATASET_PARAMETERS
 from metanorm.errors import MetadataNormalizationError
+from .data import DATASET_PARAMETERS
+
+
+class GCMDTestsBuiltin():
+    """Builtin used to easily add test methods for GCMD searches
+    """
+
+    def test_gcmd_platform(self):
+        """Test getting the platform"""
+        with mock.patch('metanorm.utils.get_gcmd_platform') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_platform({}),
+                mock_get_gcmd_method.return_value)
+
+    def test_gcmd_instrument(self):
+        """Test getting the instrument"""
+        with mock.patch('metanorm.utils.get_gcmd_instrument') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_instrument({}),
+                mock_get_gcmd_method.return_value)
 
 
 class CMEMSMetadataNormalizerTestCase(unittest.TestCase):
@@ -43,17 +62,12 @@ class CMEMSMetadataNormalizerTestCase(unittest.TestCase):
         with self.assertRaises(MetadataNormalizationError):
             self.normalizer.get_entry_id({})
 
-    def test_provider(self):
-        """The provider is always CMEMS"""
-        self.assertEqual(
-            self.normalizer.get_provider({}),
-            OrderedDict([('Bucket_Level0', 'MULTINATIONAL ORGANIZATIONS'),
-                         ('Bucket_Level1', ''),
-                         ('Bucket_Level2', ''),
-                         ('Bucket_Level3', ''),
-                         ('Short_Name', 'CMEMS'),
-                         ('Long_Name', 'Copernicus - Marine Environment Monitoring Service'),
-                         ('Data_Center_URL', '')]))
+    def test_gcmd_provider(self):
+        """Test getting the provider"""
+        with mock.patch('metanorm.utils.get_gcmd_provider') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_provider({}),
+                mock_get_gcmd_method.return_value)
 
     def test_time_coverage(self):
         """Test that the time coverage is extracted using
@@ -83,7 +97,7 @@ class CMEMSMetadataNormalizerTestCase(unittest.TestCase):
             self.normalizer.get_time_coverage_end({})
 
 
-class CMEMS008046MetadataNormalizerTestCase(unittest.TestCase):
+class CMEMS008046MetadataNormalizerTestCase(GCMDTestsBuiltin, unittest.TestCase):
     """Tests for the CMEMS008046MetadataNormalizer class"""
 
     def setUp(self):
@@ -132,26 +146,6 @@ class CMEMS008046MetadataNormalizerTestCase(unittest.TestCase):
                        'nrt_global_allsat_phy_l4_20190403_20200320.nc'}),
             datetime(year=2019, month=4, day=3, hour=12, minute=0, second=0, tzinfo=timezone.utc))
 
-    def test_platform(self):
-        """platform from CMEMS008046MetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_platform({}),
-            OrderedDict([('Category', 'Earth Observation Satellites'),
-                        ('Series_Entity', ''),
-                        ('Short_Name', ''),
-                        ('Long_Name', '')]))
-
-    def test_instrument(self):
-        """instrument from CMEMS008046MetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_instrument({}),
-            OrderedDict([('Category', 'Earth Remote Sensing Instruments'),
-                         ('Class', 'Active Remote Sensing'),
-                         ('Type', 'Altimeters'),
-                         ('Subtype', ''),
-                         ('Short_Name', ''),
-                         ('Long_Name', '')]))
-
     def test_location_geometry(self):
         """geometry from CMEMS008046MetadataNormalizer """
         self.assertEqual(
@@ -174,7 +168,7 @@ class CMEMS008046MetadataNormalizerTestCase(unittest.TestCase):
             ])
 
 
-class CMEMS015003MetadataNormalizerTestCase(unittest.TestCase):
+class CMEMS015003MetadataNormalizerTestCase(GCMDTestsBuiltin, unittest.TestCase):
     """Tests for the CMEMS015003MetadataNormalizer class"""
 
     def setUp(self):
@@ -270,26 +264,6 @@ class CMEMS015003MetadataNormalizerTestCase(unittest.TestCase):
                        'dataset-uv-nrt-hourly_20200906T0000Z_P20200918T0000.nc'}),
             datetime(year=2020, month=9, day=7, hour=0, minute=0, second=0, tzinfo=timezone.utc))
 
-    def test_platform(self):
-        """platform from CMEMS015003MetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_platform({}),
-            OrderedDict([('Category', 'Earth Observation Satellites'),
-                        ('Series_Entity', ''),
-                        ('Short_Name', ''),
-                        ('Long_Name', '')]))
-
-    def test_instrument(self):
-        """instrument from CMEMS015003MetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_instrument({}),
-            OrderedDict([('Category', 'Earth Remote Sensing Instruments'),
-                         ('Class', 'Active Remote Sensing'),
-                         ('Type', 'Altimeters'),
-                         ('Subtype', ''),
-                         ('Short_Name', ''),
-                         ('Long_Name', '')]))
-
     def test_location_geometry(self):
         """geometry from CMEMS015003MetadataNormalizer """
         self.assertEqual(
@@ -306,7 +280,7 @@ class CMEMS015003MetadataNormalizerTestCase(unittest.TestCase):
             ])
 
 
-class CMEMS001024MetadataNormalizerTestCase(unittest.TestCase):
+class CMEMS001024MetadataNormalizerTestCase(GCMDTestsBuiltin, unittest.TestCase):
     """Tests for the CMEMS001024MetadataNormalizer class"""
 
     def setUp(self):
@@ -482,26 +456,6 @@ class CMEMS001024MetadataNormalizerTestCase(unittest.TestCase):
                        'mercatorpsy4v3r1_gl12_mean_201807.nc'}),
             datetime(year=2018, month=8, day=1, hour=0, minute=0, second=0, tzinfo=timezone.utc))
 
-    def test_platform(self):
-        """platform from CMEMS001024MetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_platform({}),
-            OrderedDict([('Category', 'Models/Analyses'),
-                         ('Series_Entity', ''),
-                         ('Short_Name', 'OPERATIONAL MODELS'),
-                         ('Long_Name', '')]))
-
-    def test_instrument(self):
-        """instrument from CMEMS001024MetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_instrument({}),
-            OrderedDict([('Category', 'In Situ/Laboratory Instruments'),
-                         ('Class', 'Data Analysis'),
-                         ('Type', 'Environmental Modeling'),
-                         ('Subtype', ''),
-                         ('Short_Name', 'Computer'),
-                         ('Long_Name', 'Computer')]))
-
     def test_location_geometry(self):
         """geometry from CMEMS001024MetadataNormalizer """
         self.assertEqual(
@@ -527,7 +481,7 @@ class CMEMS001024MetadataNormalizerTestCase(unittest.TestCase):
             ])
 
 
-class CMEMS006013MetadataNormalizerTestCase(unittest.TestCase):
+class CMEMS006013MetadataNormalizerTestCase(GCMDTestsBuiltin, unittest.TestCase):
     """Tests for the CMEMS006013MetadataNormalizer class"""
 
     def setUp(self):
@@ -649,26 +603,6 @@ class CMEMS006013MetadataNormalizerTestCase(unittest.TestCase):
             self.normalizer.get_time_coverage_end({'url': url}),
             datetime(year=2021, month=7, day=1, hour=0, minute=0, second=0, tzinfo=timezone.utc))
 
-    def test_platform(self):
-        """platform from CMEMS006013MetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_platform({}),
-            OrderedDict([('Category', 'Models/Analyses'),
-                         ('Series_Entity', ''),
-                         ('Short_Name', 'OPERATIONAL MODELS'),
-                         ('Long_Name', '')]))
-
-    def test_instrument(self):
-        """instrument from CMEMS006013MetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_instrument({}),
-            OrderedDict([('Category', 'In Situ/Laboratory Instruments'),
-                         ('Class', 'Data Analysis'),
-                         ('Type', 'Environmental Modeling'),
-                         ('Subtype', ''),
-                         ('Short_Name', 'Computer'),
-                         ('Long_Name', 'Computer')]))
-
     def test_location_geometry(self):
         """geometry from CMEMS006013MetadataNormalizer """
         self.assertEqual(
@@ -763,7 +697,7 @@ class CMEMS006013MetadataNormalizerTestCase(unittest.TestCase):
             self.normalizer.get_dataset_parameters({})
 
 
-class CMEMS005001MetadataNormalizerTestCase(unittest.TestCase):
+class CMEMS005001MetadataNormalizerTestCase(GCMDTestsBuiltin, unittest.TestCase):
     """Tests for the CMEMS005001MetadataNormalizer class"""
 
     def setUp(self):
@@ -895,26 +829,6 @@ class CMEMS005001MetadataNormalizerTestCase(unittest.TestCase):
                        'CMEMS_v5r1_IBI_PHY_NRT_PdE_01mav_20191001_20191031_R20191031_AN01.nc'
             }),
             datetime(year=2019, month=11, day=1, hour=0, minute=0, second=0, tzinfo=timezone.utc))
-
-    def test_platform(self):
-        """platform from CMEMS005001MetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_platform({}),
-            OrderedDict([('Category', 'Models/Analyses'),
-                         ('Series_Entity', ''),
-                         ('Short_Name', 'OPERATIONAL MODELS'),
-                         ('Long_Name', '')]))
-
-    def test_instrument(self):
-        """instrument from CMEMS005001MetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_instrument({}),
-            OrderedDict([('Category', 'In Situ/Laboratory Instruments'),
-                         ('Class', 'Data Analysis'),
-                         ('Type', 'Environmental Modeling'),
-                         ('Subtype', ''),
-                         ('Short_Name', 'Computer'),
-                         ('Long_Name', 'Computer')]))
 
     def test_location_geometry(self):
         """geometry from CMEMS005001MetadataNormalizer """

--- a/tests/normalizers/test_cmems.py
+++ b/tests/normalizers/test_cmems.py
@@ -1070,3 +1070,355 @@ class CMEMS002003MetadataNormalizerTestCase(GCMDTestsBuiltin, unittest.TestCase)
         self.assertEqual(
             self.normalizer.get_location_geometry({}),
             'POLYGON((-180 53, -180 90, 180 90, 180 53, -180 53))')
+
+
+class CMEMS002001aMetadataNormalizerTestCase(GCMDTestsBuiltin, unittest.TestCase):
+    """Tests for the CMEMS002001aMetadataNormalizer class"""
+
+    def setUp(self):
+        self.normalizer = normalizers.geospaas.CMEMS002001aMetadataNormalizer()
+
+    def test_check(self):
+        """Test the checking condition"""
+        self.assertTrue(self.normalizer.check({
+            'url': 'ftp://nrt.cmems-du.eu/Core/ARCTIC_ANALYSIS_FORECAST_PHYS_002_001_a/'
+                   'dataset-topaz4-arc-myoceanv2-be/'
+                   '20180104_dm-metno-MODEL-topaz4-ARC-b20180108-fv02.0.nc'}))
+
+        self.assertFalse(self.normalizer.check({}))
+        self.assertFalse(self.normalizer.check({'url': 'ftp://foo/bar'}))
+
+    def test_entry_title(self):
+        """test getting entry_title"""
+        self.assertEqual(
+            self.normalizer.get_entry_title({}),
+            'Arctic Ocean Physics Analysis and Forecast')
+
+    def test_summary(self):
+        """test getting summary"""
+        self.assertEqual(
+            self.normalizer.get_summary({}),
+            'Description: The operational TOPAZ4 Arctic Ocean system uses the HYCOM model and a '
+            '100-member EnKF assimilation scheme. It is run daily to provide 10 days of forecast'
+            '(average of 10 members) of the 3D physical ocean, including sea ice data assimilation '
+            'is performed weekly to provide 7 days of analysis(ensemble average). Output products '
+            'are interpolated on a grid of 12.5 km resolution at the North Pole (equivalent to '
+            '1/8 deg in mid-latitudes) on a polar stereographic projection.;'
+            'Processing level: 4;'
+            'Product: ARCTIC_ANALYSIS_FORECAST_PHYS_002_001_a')
+
+    def test_time_coverage_start_dm(self):
+        """Should return the proper starting time"""
+        self.assertEqual(
+            self.normalizer.get_time_coverage_start({
+                'url': 'ftp://nrt.cmems-du.eu/Core/ARCTIC_ANALYSIS_FORECAST_PHYS_002_001_a/'
+                       'dataset-topaz4-arc-myoceanv2-be/'
+                       '20180104_dm-metno-MODEL-topaz4-ARC-b20180108-fv02.0.nc'
+            }),
+            datetime(year=2018, month=1, day=4, hour=0, minute=0, second=0, tzinfo=timezone.utc))
+
+    def test_time_coverage_start_hourly(self):
+        """Should return the proper starting time"""
+        self.assertEqual(
+            self.normalizer.get_time_coverage_start({
+                'url': 'ftp://nrt.cmems-du.eu/Core/ARCTIC_ANALYSIS_FORECAST_PHYS_002_001_a/'
+                       'dataset-topaz4-arc-1hr-myoceanv2-be/'
+                       '20180102_hr-metno-MODEL-topaz4-ARC-b20180102-fv02.0.nc'
+            }),
+            datetime(year=2018, month=1, day=2, hour=0, minute=0, second=0, tzinfo=timezone.utc))
+
+    def test_time_coverage_end_dm(self):
+        """Should return the proper end time"""
+        self.assertEqual(
+            self.normalizer.get_time_coverage_end({
+                'url': 'ftp://nrt.cmems-du.eu/Core/ARCTIC_ANALYSIS_FORECAST_PHYS_002_001_a/'
+                       'dataset-topaz4-arc-myoceanv2-be/'
+                       '20180104_dm-metno-MODEL-topaz4-ARC-b20180108-fv02.0.nc'
+            }),
+            datetime(year=2018, month=1, day=5, hour=0, minute=0, second=0, tzinfo=timezone.utc))
+
+    def test_time_coverage_end_hourly(self):
+        """Should return the proper end time"""
+        self.assertEqual(
+            self.normalizer.get_time_coverage_end({
+                'url': 'ftp://nrt.cmems-du.eu/Core/ARCTIC_ANALYSIS_FORECAST_PHYS_002_001_a/'
+                       'dataset-topaz4-arc-1hr-myoceanv2-be/'
+                       '20180102_hr-metno-MODEL-topaz4-ARC-b20180102-fv02.0.nc'
+            }),
+            datetime(year=2018, month=1, day=3, hour=0, minute=0, second=0, tzinfo=timezone.utc))
+
+    def test_location_geometry(self):
+        """test getting geometry"""
+        self.assertEqual(
+            self.normalizer.get_location_geometry({}),
+            'POLYGON((-180 62, -180 90, 180 90, 180 62, -180 62))')
+
+
+class CMEMS002001MetadataNormalizerTestCase(GCMDTestsBuiltin, unittest.TestCase):
+    """Tests for the CMEMS002001MetadataNormalizer class"""
+
+    def setUp(self):
+        self.normalizer = normalizers.geospaas.CMEMS002001MetadataNormalizer()
+
+    def test_check(self):
+        """Test the checking condition"""
+        self.assertTrue(self.normalizer.check({
+            'url': 'https://thredds.met.no/thredds/dodsC/cmems/topaz5_phy_dm_files/2022/'
+                   '09/20220929_dm-metno-MODEL-topaz5-ARC-b20220922-fv02.0.nc.html'}))
+
+        self.assertFalse(self.normalizer.check({}))
+        self.assertFalse(self.normalizer.check({'url': 'https://foo/bar'}))
+
+    def test_entry_title(self):
+        """test getting entry_title"""
+        self.assertEqual(
+            self.normalizer.get_entry_title({}),
+            'Arctic Ocean Physics Analysis and Forecast, 6.25 km')
+
+    def test_summary(self):
+        """test getting summary"""
+        self.assertEqual(
+            self.normalizer.get_summary({}),
+            'Description: TOPAZ 5 physical model;'
+            'Processing level: 4;'
+            'Product: ARCTIC_ANALYSISFORECAST_PHY_002_001')
+
+    def test_time_coverage_start_dm(self):
+        """Should return the proper starting time"""
+        self.assertEqual(
+            self.normalizer.get_time_coverage_start({
+                'url': 'https://thredds.met.no/thredds/dodsC/cmems/topaz5_phy_dm_files/2022/09/'
+                       '20220929_dm-metno-MODEL-topaz5-ARC-b20220922-fv02.0.nc.html'
+            }),
+            datetime(year=2022, month=9, day=29, hour=0, minute=0, second=0, tzinfo=timezone.utc))
+
+    def test_time_coverage_start_hourly(self):
+        """Should return the proper starting time"""
+        self.assertEqual(
+            self.normalizer.get_time_coverage_start({
+                'url': 'https://thredds.met.no/thredds/dodsC/cmems/topaz5_phy_hr_files/2021/11/'
+                       '20211130_hr-metno-MODEL-topaz5-ARC-b20211130-fv02.0.nc.html'
+            }),
+            datetime(year=2021, month=11, day=30, hour=0, minute=0, second=0, tzinfo=timezone.utc))
+
+    def test_time_coverage_end_dm(self):
+        """Should return the proper end time"""
+        self.assertEqual(
+            self.normalizer.get_time_coverage_end({
+                'url': 'https://thredds.met.no/thredds/dodsC/cmems/topaz5_phy_dm_files/2022/09/'
+                       '20220929_dm-metno-MODEL-topaz5-ARC-b20220922-fv02.0.nc.html'
+            }),
+            datetime(year=2022, month=9, day=30, hour=0, minute=0, second=0, tzinfo=timezone.utc))
+
+    def test_time_coverage_end_hourly(self):
+        """Should return the proper end time"""
+        self.assertEqual(
+            self.normalizer.get_time_coverage_end({
+                'url': 'https://thredds.met.no/thredds/dodsC/cmems/topaz5_phy_hr_files/2021/11/'
+                       '20211130_hr-metno-MODEL-topaz5-ARC-b20211130-fv02.0.nc.html'
+            }),
+            datetime(year=2021, month=12, day=1, hour=0, minute=0, second=0, tzinfo=timezone.utc))
+
+    def test_location_geometry(self):
+        """test getting geometry"""
+        self.assertEqual(
+            self.normalizer.get_location_geometry({}),
+            'POLYGON((-180 50, -180 90, 180 90, 180 50, -180 50))')
+
+    def test_dataset_parameters(self):
+        """Test getting the dataset parameters"""
+        with self.subTest('hourly'):
+            attributes = {
+                'url': 'https://thredds.met.no/thredds/dodsC/cmems/topaz5_phy_hr_files/2021/11/'
+                       '20211130_hr-metno-MODEL-topaz5-ARC-b20211130-fv02.0.nc.html'
+            }
+            with mock.patch('metanorm.utils.create_parameter_list') as mock_utils_method:
+                self.assertEqual(
+                    self.normalizer.get_dataset_parameters(attributes),
+                    mock_utils_method.return_value)
+                mock_utils_method.assert_called_once_with(
+                    (
+                        'longitude',
+                        'latitude',
+                        'sea_floor_depth_below_geoid',
+                        'sea_water_salinity',
+                        'sea_water_potential_temperature',
+                        'sea_ice_area_fraction',
+                        'sea_ice_thickness',
+                        'surface_snow_thickness',
+                        'sea_ice_x_velocity',
+                        'sea_ice_y_velocity',
+                        'sea_surface_height_above_geoid',
+                        'sea_water_x_velocity',
+                        'sea_water_y_velocity',
+                    )
+                )
+        with self.subTest('daily mean'):
+            attributes = {
+                'url': 'https://thredds.met.no/thredds/dodsC/cmems/topaz5_phy_dm_files/2022/09/'
+                       '20220929_dm-metno-MODEL-topaz5-ARC-b20220922-fv02.0.nc.html'
+            }
+            with mock.patch('metanorm.utils.create_parameter_list') as mock_utils_method:
+                self.assertEqual(
+                    self.normalizer.get_dataset_parameters(attributes),
+                    mock_utils_method.return_value)
+                mock_utils_method.assert_called_once_with(
+                    (
+                        'longitude',
+                        'latitude',
+                        'depth',
+                        'sea_floor_depth_below_geoid',
+                        'sea_water_potential_temperature',
+                        'sea_water_salinity',
+                        'sea_water_x_velocity',
+                        'sea_water_y_velocity',
+                        'ocean_mixed_layer_thickness_defined_by_sigma_theta',
+                        'sea_surface_height_above_geoid',
+                        'ocean_barotropic_streamfunction',
+                        'sea_ice_area_fraction',
+                        'sea_ice_thickness',
+                        'sea_ice_x_velocity',
+                        'sea_ice_y_velocity',
+                        'surface_snow_thickness',
+                        'age_of_sea_ice',
+                        'sea_ice_classification',
+                        'sea_ice_albedo',
+                        'sea_water_potential_temperature_at_sea_floor',
+                    )
+                )
+
+
+class CMEMS002004MetadataNormalizerTestCase(GCMDTestsBuiltin, unittest.TestCase):
+    """Tests for the CMEMS002004MetadataNormalizer class"""
+
+    def setUp(self):
+        self.normalizer = normalizers.geospaas.CMEMS002004MetadataNormalizer()
+
+    def test_check(self):
+        """Test the checking condition"""
+        self.assertTrue(self.normalizer.check({
+            'url': 'https://thredds.met.no/thredds/dodsC/cmems/topaz5_bgc_dm_files/2021/10/'
+                   '20211031_dm-metno-MODEL-topaz5_ecosmo-ARC-b20211028-fv02.0.nc.html'}))
+
+        self.assertFalse(self.normalizer.check({}))
+        self.assertFalse(self.normalizer.check({'url': 'https://foo/bar'}))
+
+    def test_entry_title(self):
+        """test getting entry_title"""
+        self.assertEqual(
+            self.normalizer.get_entry_title({}),
+            'Arctic Ocean Biogeochemistry Analysis and Forecast, 6.25 km')
+
+    def test_summary(self):
+        """test getting summary"""
+        self.assertEqual(
+            self.normalizer.get_summary({}),
+            'Description: TOPAZ 5 biochemistry model;'
+            'Processing level: 4;'
+            'Product: ARCTIC_ANALYSISFORECAST_BGC_002_004')
+
+    def test_time_coverage_start_dm(self):
+        """Should return the proper starting time"""
+        self.assertEqual(
+            self.normalizer.get_time_coverage_start({
+                'url': 'https://thredds.met.no/thredds/dodsC/cmems/topaz5_bgc_dm_files/2021/10/'
+                       '20211031_dm-metno-MODEL-topaz5_ecosmo-ARC-b20211028-fv02.0.nc.html'
+            }),
+            datetime(year=2021, month=10, day=31, hour=0, minute=0, second=0, tzinfo=timezone.utc))
+
+    def test_time_coverage_start_mm(self):
+        """Should return the proper starting time"""
+        self.assertEqual(
+            self.normalizer.get_time_coverage_start({
+                'url': 'https://thredds.met.no/thredds/dodsC/cmems/topaz5_bgc_mm_files/2020/'
+                       '202011_mm-metno-MODEL-topaz5_ecosmo-ARC-fv02.0.nc.html'
+            }),
+            datetime(year=2020, month=11, day=1, hour=0, minute=0, second=0, tzinfo=timezone.utc))
+
+    def test_time_coverage_end_dm(self):
+        """Should return the proper end time"""
+        self.assertEqual(
+            self.normalizer.get_time_coverage_end({
+                'url': 'https://thredds.met.no/thredds/dodsC/cmems/topaz5_bgc_dm_files/2021/10/'
+                       '20211031_dm-metno-MODEL-topaz5_ecosmo-ARC-b20211028-fv02.0.nc.html'
+            }),
+            datetime(year=2021, month=11, day=1, hour=0, minute=0, second=0, tzinfo=timezone.utc))
+
+    def test_time_coverage_end_mm(self):
+        """Should return the proper end time"""
+        self.assertEqual(
+            self.normalizer.get_time_coverage_end({
+                'url': 'https://thredds.met.no/thredds/dodsC/cmems/topaz5_bgc_mm_files/2020/'
+                       '202011_mm-metno-MODEL-topaz5_ecosmo-ARC-fv02.0.nc.html'
+            }),
+            datetime(year=2020, month=12, day=1, hour=0, minute=0, second=0, tzinfo=timezone.utc))
+
+    def test_location_geometry(self):
+        """test getting geometry"""
+        self.assertEqual(
+            self.normalizer.get_location_geometry({}),
+            'POLYGON((-180 50, -180 90, 180 90, 180 50, -180 50))')
+
+    def test_dataset_parameters(self):
+        """Test getting the dataset parameters"""
+        with self.subTest('monthly mean'):
+            attributes = {
+                'url': 'https://thredds.met.no/thredds/dodsC/cmems/topaz5_bgc_mm_files/2020/'
+                       '202011_mm-metno-MODEL-topaz5_ecosmo-ARC-fv02.0.nc.html'
+            }
+            with mock.patch('metanorm.utils.create_parameter_list') as mock_utils_method:
+                self.assertEqual(
+                    self.normalizer.get_dataset_parameters(attributes),
+                    mock_utils_method.return_value)
+                mock_utils_method.assert_called_once_with(
+                    (
+                        'longitude',
+                        'latitude',
+                        'sea_floor_depth_below_geoid',
+                        ('net_primary_production_of_biomass_'
+                         'expressed_as_carbon_per_unit_volume_in_sea_water'),
+                        'mass_concentration_of_chlorophyll_a_in_sea_water',
+                        'volume_attenuation_coefficient_of_downwelling_radiative_flux_in_sea_water',
+                        'mole_concentration_of_nitrate_in_sea_water',
+                        'mole_concentration_of_phosphate_in_sea_water',
+                        'mole_concentration_of_phytoplankton_expressed_as_carbon_in_sea_water',
+                        'mole_concentration_of_zooplankton_expressed_as_carbon_in_sea_water',
+                        'mole_concentration_of_dissolved_molecular_oxygen_in_sea_water',
+                        'mole_concentration_of_silicate_in_sea_water',
+                        'sinking_mole_flux_of_particulate_organic_matter_expressed_as_carbon_in_sea_water',
+                        'sea_water_ph_reported_on_total_scale',
+                        'mole_concentration_of_dissolved_inorganic_carbon_in_sea_water',
+                        'surface_partial_pressure_of_carbon_dioxide_in_sea_water',
+                    )
+                )
+        with self.subTest('daily mean'):
+            attributes = {
+                'url': 'https://thredds.met.no/thredds/dodsC/cmems/topaz5_bgc_dm_files/2021/10/'
+                       '20211031_dm-metno-MODEL-topaz5_ecosmo-ARC-b20211028-fv02.0.nc.html'
+            }
+            with mock.patch('metanorm.utils.create_parameter_list') as mock_utils_method:
+                self.assertEqual(
+                    self.normalizer.get_dataset_parameters(attributes),
+                    mock_utils_method.return_value)
+                mock_utils_method.assert_called_once_with(
+                    (
+                        'longitude',
+                        'latitude',
+                        'depth',
+                        'sea_floor_depth_below_geoid',
+                        ('net_primary_production_of_biomass_'
+                         'expressed_as_carbon_per_unit_volume_in_sea_water'),
+                        'mass_concentration_of_chlorophyll_a_in_sea_water',
+                        'volume_attenuation_coefficient_of_downwelling_radiative_flux_in_sea_water',
+                        'mole_concentration_of_nitrate_in_sea_water',
+                        'mole_concentration_of_phosphate_in_sea_water',
+                        'mole_concentration_of_phytoplankton_expressed_as_carbon_in_sea_water',
+                        'mole_concentration_of_zooplankton_expressed_as_carbon_in_sea_water',
+                        'mole_concentration_of_dissolved_molecular_oxygen_in_sea_water',
+                        'mole_concentration_of_silicate_in_sea_water',
+                        'sinking_mole_flux_of_particulate_organic_matter_expressed_as_carbon_in_sea_water',
+                        'sea_water_ph_reported_on_total_scale',
+                        'mole_concentration_of_dissolved_inorganic_carbon_in_sea_water',
+                        'surface_partial_pressure_of_carbon_dioxide_in_sea_water',
+                    )
+                )

--- a/tests/normalizers/test_cmems.py
+++ b/tests/normalizers/test_cmems.py
@@ -28,7 +28,7 @@ class GCMDTestsBuiltin():
                 mock_get_gcmd_method.return_value)
 
     def test_dataset_parameters(self):
-        """Test getting the instrument dataset parameters"""
+        """Test getting the dataset parameters"""
         with mock.patch('metanorm.utils.create_parameter_list') as mock_get_gcmd_method:
             self.assertEqual(
                 self.normalizer.get_dataset_parameters(mock.MagicMock()),
@@ -1019,7 +1019,7 @@ class CMEMS002003MetadataNormalizerTestCase(GCMDTestsBuiltin, unittest.TestCase)
         """Should return the proper starting time"""
         self.assertEqual(
             self.normalizer.get_time_coverage_start({
-                'url': 'ftp://aperrin@my.cmems-du.eu/Core/ARCTIC_MULTIYEAR_PHY_002_003/'
+                'url': 'ftp://my.cmems-du.eu/Core/ARCTIC_MULTIYEAR_PHY_002_003/'
                        'cmems_mod_arc_phy_my_topaz4_P1M/'
                        '19910115_mm-12km-NERSC-MODEL-TOPAZ4B-ARC-RAN.fv2.0.nc'
             }),
@@ -1029,7 +1029,7 @@ class CMEMS002003MetadataNormalizerTestCase(GCMDTestsBuiltin, unittest.TestCase)
         """Should return the proper starting time"""
         self.assertEqual(
             self.normalizer.get_time_coverage_start({
-                'url': 'ftp://aperrin@my.cmems-du.eu/Core/ARCTIC_MULTIYEAR_PHY_002_003/'
+                'url': 'ftp://my.cmems-du.eu/Core/ARCTIC_MULTIYEAR_PHY_002_003/'
                 'cmems_mod_arc_phy_my_topaz4_P1M/'
                 '19910101_ym-12km-NERSC-MODEL-TOPAZ4B-ARC-RAN.fv2.0.nc'
             }),

--- a/tests/normalizers/test_cmems.py
+++ b/tests/normalizers/test_cmems.py
@@ -9,8 +9,8 @@ import metanorm.normalizers as normalizers
 from metanorm.errors import MetadataNormalizationError
 
 
-class GCMDTestsBuiltin():
-    """Builtin used to easily add test methods for GCMD searches
+class GCMDTestsMixin():
+    """Mixin used to easily add test methods for GCMD searches
     """
 
     def test_gcmd_platform(self):
@@ -102,7 +102,7 @@ class CMEMSMetadataNormalizerTestCase(unittest.TestCase):
             self.normalizer.get_time_coverage_end({})
 
 
-class CMEMS008046MetadataNormalizerTestCase(GCMDTestsBuiltin, unittest.TestCase):
+class CMEMS008046MetadataNormalizerTestCase(GCMDTestsMixin, unittest.TestCase):
     """Tests for the CMEMS008046MetadataNormalizer class"""
 
     def setUp(self):
@@ -158,7 +158,7 @@ class CMEMS008046MetadataNormalizerTestCase(GCMDTestsBuiltin, unittest.TestCase)
             'POLYGON((-180 -90, -180 90, 180 90, 180 -90, -180 -90))')
 
 
-class CMEMS015003MetadataNormalizerTestCase(GCMDTestsBuiltin, unittest.TestCase):
+class CMEMS015003MetadataNormalizerTestCase(GCMDTestsMixin, unittest.TestCase):
     """Tests for the CMEMS015003MetadataNormalizer class"""
 
     def setUp(self):
@@ -261,7 +261,7 @@ class CMEMS015003MetadataNormalizerTestCase(GCMDTestsBuiltin, unittest.TestCase)
             'POLYGON((-180 -90, -180 90, 180 90, 180 -90, -180 -90))')
 
 
-class CMEMS001024MetadataNormalizerTestCase(GCMDTestsBuiltin, unittest.TestCase):
+class CMEMS001024MetadataNormalizerTestCase(GCMDTestsMixin, unittest.TestCase):
     """Tests for the CMEMS001024MetadataNormalizer class"""
 
     def setUp(self):
@@ -444,7 +444,7 @@ class CMEMS001024MetadataNormalizerTestCase(GCMDTestsBuiltin, unittest.TestCase)
             'POLYGON((-180 -90, -180 90, 180 90, 180 -90, -180 -90))')
 
 
-class CMEMS006013MetadataNormalizerTestCase(GCMDTestsBuiltin, unittest.TestCase):
+class CMEMS006013MetadataNormalizerTestCase(GCMDTestsMixin, unittest.TestCase):
     """Tests for the CMEMS006013MetadataNormalizer class"""
 
     def setUp(self):
@@ -711,7 +711,7 @@ class CMEMS006013MetadataNormalizerTestCase(GCMDTestsBuiltin, unittest.TestCase)
             self.normalizer.get_dataset_parameters({})
 
 
-class CMEMS005001MetadataNormalizerTestCase(GCMDTestsBuiltin, unittest.TestCase):
+class CMEMS005001MetadataNormalizerTestCase(GCMDTestsMixin, unittest.TestCase):
     """Tests for the CMEMS005001MetadataNormalizer class"""
 
     def setUp(self):
@@ -970,7 +970,7 @@ class CMEMS005001MetadataNormalizerTestCase(GCMDTestsBuiltin, unittest.TestCase)
             self.normalizer.get_dataset_parameters({})
 
 
-class CMEMS002003MetadataNormalizerTestCase(GCMDTestsBuiltin, unittest.TestCase):
+class CMEMS002003MetadataNormalizerTestCase(GCMDTestsMixin, unittest.TestCase):
     """Tests for the CMEMS002003MetadataNormalizer class"""
 
     def setUp(self):
@@ -1072,7 +1072,7 @@ class CMEMS002003MetadataNormalizerTestCase(GCMDTestsBuiltin, unittest.TestCase)
             'POLYGON((-180 53, -180 90, 180 90, 180 53, -180 53))')
 
 
-class CMEMS002001aMetadataNormalizerTestCase(GCMDTestsBuiltin, unittest.TestCase):
+class CMEMS002001aMetadataNormalizerTestCase(GCMDTestsMixin, unittest.TestCase):
     """Tests for the CMEMS002001aMetadataNormalizer class"""
 
     def setUp(self):
@@ -1158,7 +1158,7 @@ class CMEMS002001aMetadataNormalizerTestCase(GCMDTestsBuiltin, unittest.TestCase
         self.assertEqual(self.normalizer.get_dataset_parameters({'url': 'https://foo'}), [])
 
 
-class CMEMS002001MetadataNormalizerTestCase(GCMDTestsBuiltin, unittest.TestCase):
+class CMEMS002001MetadataNormalizerTestCase(GCMDTestsMixin, unittest.TestCase):
     """Tests for the CMEMS002001MetadataNormalizer class"""
 
     def setUp(self):
@@ -1300,7 +1300,7 @@ class CMEMS002001MetadataNormalizerTestCase(GCMDTestsBuiltin, unittest.TestCase)
                 self.assertEqual(self.normalizer.get_dataset_parameters({'url': 'https://foo'}), [])
 
 
-class CMEMS002004MetadataNormalizerTestCase(GCMDTestsBuiltin, unittest.TestCase):
+class CMEMS002004MetadataNormalizerTestCase(GCMDTestsMixin, unittest.TestCase):
     """Tests for the CMEMS002004MetadataNormalizer class"""
 
     def setUp(self):

--- a/tests/normalizers/test_cmems.py
+++ b/tests/normalizers/test_cmems.py
@@ -968,3 +968,105 @@ class CMEMS005001MetadataNormalizerTestCase(GCMDTestsBuiltin, unittest.TestCase)
         """An exception must be raised if the attribute is missing"""
         with self.assertRaises(MetadataNormalizationError):
             self.normalizer.get_dataset_parameters({})
+
+
+class CMEMS002003MetadataNormalizerTestCase(GCMDTestsBuiltin, unittest.TestCase):
+    """Tests for the CMEMS002003MetadataNormalizer class"""
+
+    def setUp(self):
+        self.normalizer = normalizers.geospaas.CMEMS002003MetadataNormalizer()
+
+    def test_check(self):
+        """Test the checking condition"""
+        self.assertTrue(self.normalizer.check({
+            'url': 'ftp://my.cmems-du.eu/Core/ARCTIC_MULTIYEAR_PHY_002_003/'
+                    'cmems_mod_arc_phy_my_topaz4_P1D-m/2021/02/'
+                    '20210204_dm-12km-NERSC-MODEL-TOPAZ4B-ARC-RAN.fv2.0.nc'}))
+
+        self.assertFalse(self.normalizer.check({}))
+        self.assertFalse(self.normalizer.check({'url': 'ftp://foo/bar'}))
+
+    def test_entry_title(self):
+        """test getting entry_title"""
+        self.assertEqual(
+            self.normalizer.get_entry_title({}),
+            'Arctic Ocean Physics Reanalysis')
+
+    def test_summary(self):
+        """test getting summary"""
+        self.assertEqual(
+            self.normalizer.get_summary({}),
+            'Description: The current version of the TOPAZ system - TOPAZ4b - is nearly identical '
+                'to the real-time forecast system run at MET Norway. It uses a recent version of '
+                'the Hybrid Coordinate Ocean Model (HYCOM) developed at University of Miami (Bleck '
+                '2002). HYCOM is coupled to a sea ice model; ice thermodynamics are described in '
+                'Drange and Simonsen (1996) and the elastic-viscous-plastic rheology in Hunke and '
+                'Dukowicz (1997).;'
+            'Processing level: 4;'
+            'Product: ARCTIC_MULTIYEAR_PHY_002_003')
+
+    def test_time_coverage_start_dm(self):
+        """Should return the proper starting time"""
+        self.assertEqual(
+            self.normalizer.get_time_coverage_start({
+                'url': 'ftp://my.cmems-du.eu/Core/ARCTIC_MULTIYEAR_PHY_002_003/'
+                       'cmems_mod_arc_phy_my_topaz4_P1D-m/2021/02/'
+                       '20210204_dm-12km-NERSC-MODEL-TOPAZ4B-ARC-RAN.fv2.0.nc'
+            }),
+            datetime(year=2021, month=2, day=4, hour=0, minute=0, second=0, tzinfo=timezone.utc))
+
+    def test_time_coverage_start_mm(self):
+        """Should return the proper starting time"""
+        self.assertEqual(
+            self.normalizer.get_time_coverage_start({
+                'url': 'ftp://aperrin@my.cmems-du.eu/Core/ARCTIC_MULTIYEAR_PHY_002_003/'
+                       'cmems_mod_arc_phy_my_topaz4_P1M/'
+                       '19910115_mm-12km-NERSC-MODEL-TOPAZ4B-ARC-RAN.fv2.0.nc'
+            }),
+            datetime(year=1991, month=1, day=1, hour=0, minute=0, second=0, tzinfo=timezone.utc))
+
+    def test_time_coverage_start_ym(self):
+        """Should return the proper starting time"""
+        self.assertEqual(
+            self.normalizer.get_time_coverage_start({
+                'url': 'ftp://aperrin@my.cmems-du.eu/Core/ARCTIC_MULTIYEAR_PHY_002_003/'
+                'cmems_mod_arc_phy_my_topaz4_P1M/'
+                '19910101_ym-12km-NERSC-MODEL-TOPAZ4B-ARC-RAN.fv2.0.nc'
+            }),
+            datetime(year=1991, month=1, day=1, hour=0, minute=0, second=0, tzinfo=timezone.utc))
+
+    def test_time_coverage_end_dm(self):
+        """Should return the proper end time"""
+        self.assertEqual(
+            self.normalizer.get_time_coverage_end({
+                'url': 'ftp://my.cmems-du.eu/Core/ARCTIC_MULTIYEAR_PHY_002_003/'
+                       'cmems_mod_arc_phy_my_topaz4_P1D-m/2021/02/'
+                       '20210204_dm-12km-NERSC-MODEL-TOPAZ4B-ARC-RAN.fv2.0.nc'
+            }),
+            datetime(year=2021, month=2, day=5, hour=0, minute=0, second=0, tzinfo=timezone.utc))
+
+    def test_time_coverage_end_mm(self):
+        """Should return the proper end time"""
+        self.assertEqual(
+            self.normalizer.get_time_coverage_end({
+                'url': 'ftp://my.cmems-du.eu/Core/ARCTIC_MULTIYEAR_PHY_002_003/'
+                       'cmems_mod_arc_phy_my_topaz4_P1M/'
+                       '19910115_mm-12km-NERSC-MODEL-TOPAZ4B-ARC-RAN.fv2.0.nc'
+            }),
+            datetime(year=1991, month=2, day=1, hour=0, minute=0, second=0, tzinfo=timezone.utc))
+
+    def test_time_coverage_end_ym(self):
+        """Should return the proper end time"""
+        self.assertEqual(
+            self.normalizer.get_time_coverage_end({
+                'url': 'ftp://my.cmems-du.eu/Core/ARCTIC_MULTIYEAR_PHY_002_003/'
+                       'cmems_mod_arc_phy_my_topaz4_P1M/'
+                       '19910101_ym-12km-NERSC-MODEL-TOPAZ4B-ARC-RAN.fv2.0.nc'
+            }),
+            datetime(year=1992, month=1, day=1, hour=0, minute=0, second=0, tzinfo=timezone.utc))
+
+    def test_location_geometry(self):
+        """test getting geometry"""
+        self.assertEqual(
+            self.normalizer.get_location_geometry({}),
+            'POLYGON((-180 53, -180 90, 180 90, 180 53, -180 53))')

--- a/tests/normalizers/test_cmems_in_situ_tac.py
+++ b/tests/normalizers/test_cmems_in_situ_tac.py
@@ -1,5 +1,6 @@
 """Tests for the CMEMS in situ TAC metadata normalizer"""
 import unittest
+import unittest.mock as mock
 from collections import OrderedDict
 from datetime import datetime
 
@@ -187,34 +188,26 @@ class CMEMSInSituTACMetadataNormalizerTestCase(unittest.TestCase):
         with self.assertRaises(MetadataNormalizationError):
             self.normalizer.get_time_coverage_end({})
 
-    def test_get_platform(self):
-        """get_platform() should return the platform
-        of the dataset
-        """
-        self.assertEqual(
-            self.normalizer.get_platform({}),
-            OrderedDict([
-                ('Category', 'In Situ Ocean-based Platforms'),
-                ('Series_Entity', ''),
-                ('Short_Name', ''),
-                ('Long_Name', '')
-            ]))
+    def test_gcmd_platform(self):
+        """Test getting the platform"""
+        with mock.patch('metanorm.utils.get_gcmd_platform') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_platform({}),
+                mock_get_gcmd_method.return_value)
 
-    def test_get_instrument(self):
-        """get_instrument() should return the instrument
-        of the dataset
-        """
-        self.assertEqual(
-            self.normalizer.get_instrument({}),
-            OrderedDict([
-                ('Category', 'In Situ/Laboratory Instruments'),
-                ('Class', ''),
-                ('Type', ''),
-                ('Subtype', ''),
-                ('Short_Name', ''),
-                ('Long_Name', '')
-            ])
-        )
+    def test_gcmd_instrument(self):
+        """Test getting the instrument"""
+        with mock.patch('metanorm.utils.get_gcmd_instrument') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_instrument({}),
+                mock_get_gcmd_method.return_value)
+
+    def test_gcmd_provider(self):
+        """Test getting the provider"""
+        with mock.patch('metanorm.utils.get_gcmd_provider') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_provider({}),
+                mock_get_gcmd_method.return_value)
 
     def test_get_location_geometry(self):
         """get_location_geometry() should return the location
@@ -228,19 +221,3 @@ class CMEMSInSituTACMetadataNormalizerTestCase(unittest.TestCase):
         attribute is missing
         """
         self.assertEqual(self.normalizer.get_location_geometry({}), '')
-
-    def test_get_provider(self):
-        """get_provider() should return the provider
-        of the dataset
-        """
-        self.assertEqual(
-            self.normalizer.get_provider({}),
-            OrderedDict([
-                ('Bucket_Level0', 'MULTINATIONAL ORGANIZATIONS'),
-                ('Bucket_Level1', ''),
-                ('Bucket_Level2', ''),
-                ('Bucket_Level3', ''),
-                ('Short_Name', 'CMEMS'),
-                ('Long_Name', 'Copernicus - Marine Environment Monitoring Service'),
-                ('Data_Center_URL', '')
-            ]))

--- a/tests/normalizers/test_cpom.py
+++ b/tests/normalizers/test_cpom.py
@@ -1,11 +1,11 @@
 """Tests for the CPOM altimetry normalizer"""
 
 import unittest
+import unittest.mock as mock
 from collections import OrderedDict
 from datetime import datetime, timezone
 
 import metanorm.normalizers as normalizers
-from metanorm.errors import MetadataNormalizationError
 
 
 class CPOMAltimetryMetadataNormalizerTests(unittest.TestCase):
@@ -38,28 +38,26 @@ class CPOMAltimetryMetadataNormalizerTests(unittest.TestCase):
             self.normalizer.get_time_coverage_end({}),
             datetime(year=2015, month=1, day=1, tzinfo=timezone.utc))
 
-    def test_get_platform(self):
+    def test_gcmd_platform(self):
         """Test getting the platform"""
-        self.assertDictEqual(self.normalizer.get_platform({}),
-            OrderedDict([
-                ('Category', 'Earth Observation Satellites'),
-                ('Series_Entity', ''),
-                ('Short_Name', ''),
-                ('Long_Name', '')
-            ]))
+        with mock.patch('metanorm.utils.get_gcmd_platform') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_platform({}),
+                mock_get_gcmd_method.return_value)
 
-    def test_get_instrument(self):
+    def test_gcmd_instrument(self):
         """Test getting the instrument"""
-        self.assertDictEqual(
-            self.normalizer.get_instrument({}),
-            OrderedDict([
-                ('Category', 'Earth Remote Sensing Instruments'),
-                ('Class', 'Active Remote Sensing'),
-                ('Type', 'Altimeters'),
-                ('Subtype', ''),
-                ('Short_Name', ''),
-                ('Long_Name', '')
-            ]))
+        with mock.patch('metanorm.utils.get_gcmd_instrument') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_instrument({}),
+                mock_get_gcmd_method.return_value)
+
+    def test_gcmd_provider(self):
+        """Test getting the provider"""
+        with mock.patch('metanorm.utils.get_gcmd_provider') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_provider({}),
+                mock_get_gcmd_method.return_value)
 
     def test_get_location_geometry(self):
         """get_location_geometry() should return the location
@@ -74,30 +72,9 @@ class CPOMAltimetryMetadataNormalizerTests(unittest.TestCase):
         """
         self.assertEqual(self.normalizer.get_location_geometry({}), '')
 
-    def test_get_provider(self):
-        """Test getting the provider"""
-        self.assertDictEqual(
-            self.normalizer.get_provider({}),
-            OrderedDict([
-                ('Bucket_Level0', 'ACADEMIC'),
-                ('Bucket_Level1', ''),
-                ('Bucket_Level2', ''),
-                ('Bucket_Level3', ''),
-                ('Short_Name', 'UC-LONDON/CPOM'),
-                ('Long_Name', ''),
-                ('Data_Center_URL', 'http://www.cpom.ucl.ac.uk/cpom_ucl_only/data_resources.html')
-            ]))
-
-    def test_get_parameters(self):
-        """Test getting the only dataset parameter"""
-        self.assertListEqual(
-            self.normalizer.get_dataset_parameters({}),
-            [
-                OrderedDict([
-                    ('standard_name', 'sea_surface_height_above_sea_level'),
-                    ('long_name', 'Sea Surface Anomaly'),
-                    ('short_name', 'SSA'),
-                    ('units', 'm'),
-                    ('minmax', '-100 100'),
-                    ('colormap', 'jet')])
-            ])
+    def test_dataset_parameters(self):
+        """dataset_parameters from CEDAESACCIMetadataNormalizer """
+        with mock.patch('metanorm.utils.create_parameter_list') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_dataset_parameters({}),
+                mock_get_gcmd_method.return_value)

--- a/tests/normalizers/test_cpom.py
+++ b/tests/normalizers/test_cpom.py
@@ -2,7 +2,6 @@
 
 import unittest
 import unittest.mock as mock
-from collections import OrderedDict
 from datetime import datetime, timezone
 
 import metanorm.normalizers as normalizers

--- a/tests/normalizers/test_earthdata_cmr.py
+++ b/tests/normalizers/test_earthdata_cmr.py
@@ -1,6 +1,6 @@
 """Tests for the ACDD metadata normalizer"""
 import unittest
-from collections import OrderedDict
+import unittest.mock as mock
 from datetime import datetime
 
 from dateutil.tz import tzutc
@@ -163,24 +163,22 @@ class EarthdataCMRMetadataNormalizerTestCase(unittest.TestCase):
 
     def test_platform(self):
         """Test getting the platform"""
-        self.assertEqual(
-            self.normalizer.get_platform({'umm': {
-                "Platforms": [
-                    {
-                        "ShortName": "SUOMI-NPP",
-                        "Instruments": [
-                            {
-                                "ShortName": "VIIRS"
-                            }
-                        ]
-                    }
-                ]
-            }}),
-            OrderedDict([('Category', 'Earth Observation Satellites'),
-                         ('Series_Entity', 'Joint Polar Satellite System (JPSS)'),
-                         ('Short_Name', 'Suomi-NPP'),
-                         ('Long_Name', 'Suomi National Polar-orbiting Partnership')]),
-        )
+        with mock.patch('metanorm.utils.get_gcmd_platform') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_platform({'umm': {
+                    "Platforms": [
+                        {
+                            "ShortName": "SUOMI-NPP",
+                            "Instruments": [
+                                {
+                                    "ShortName": "VIIRS"
+                                }
+                            ]
+                        }
+                    ]
+                }}),
+                mock_get_gcmd_method.return_value)
+            mock_get_gcmd_method.assert_called_with('SUOMI-NPP')
 
     def test_platform_missing_attribute(self):
         """A MetadataNormalizationError must be raised if the raw
@@ -193,26 +191,22 @@ class EarthdataCMRMetadataNormalizerTestCase(unittest.TestCase):
 
     def test_instrument(self):
         """Test getting the instrument"""
-        self.assertEqual(
-            self.normalizer.get_instrument({'umm': {
-                "Platforms": [
-                    {
-                        "ShortName": "SUOMI-NPP",
-                        "Instruments": [
-                            {
-                                "ShortName": "VIIRS"
-                            }
-                        ]
-                    }
-                ]
-            }}),
-            OrderedDict([('Category', 'Earth Remote Sensing Instruments'),
-                         ('Class', 'Passive Remote Sensing'),
-                         ('Type', 'Spectrometers/Radiometers'),
-                         ('Subtype', 'Imaging Spectrometers/Radiometers'),
-                         ('Short_Name', 'VIIRS'),
-                         ('Long_Name', 'Visible-Infrared Imager-Radiometer Suite')])
-        )
+        with mock.patch('metanorm.utils.get_gcmd_instrument') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_instrument({'umm': {
+                    "Platforms": [
+                        {
+                            "ShortName": "SUOMI-NPP",
+                            "Instruments": [
+                                {
+                                    "ShortName": "VIIRS"
+                                }
+                            ]
+                        }
+                    ]
+                }}),
+                mock_get_gcmd_method.return_value)
+            mock_get_gcmd_method.assert_called_with('VIIRS')
 
     def test_instrument_missing_attribute(self):
         """A MetadataNormalizationError must be raised if the raw
@@ -264,20 +258,11 @@ class EarthdataCMRMetadataNormalizerTestCase(unittest.TestCase):
 
     def test_get_provider(self):
         """Test getting the provider"""
-        self.assertEqual(
-            self.normalizer.get_provider({"meta": {"provider-id": "OB_DAAC"}}),
-            OrderedDict([('Bucket_Level0', 'GOVERNMENT AGENCIES-U.S. FEDERAL AGENCIES'),
-                         ('Bucket_Level1', 'NASA'),
-                         ('Bucket_Level2', ''),
-                         ('Bucket_Level3', ''),
-                         ('Short_Name', 'NASA/GSFC/SED/ESD/GCDC/OB.DAAC'),
-                         ('Long_Name',
-                          'Ocean Biology Distributed Active Archive Center (OB.DAAC), '
-                          'Global Change Data Center, Earth Sciences Division, '
-                          'Science and Exploration Directorate, '
-                          'Goddard Space Flight Center, NASA'),
-                         ('Data_Center_URL', 'https://oceancolor.gsfc.nasa.gov')])
-        )
+        with mock.patch('metanorm.utils.get_gcmd_provider') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_provider({"meta": {"provider-id": "OB_DAAC"}}),
+                mock_get_gcmd_method.return_value)
+            mock_get_gcmd_method.assert_called_with(['OB_DAAC'])
 
     def test_unknown_provider_returns_none(self):
         """A MetadataNormalizationError must be raised if the provider

--- a/tests/normalizers/test_geospaas_base.py
+++ b/tests/normalizers/test_geospaas_base.py
@@ -3,7 +3,6 @@
 import logging
 import unittest
 import unittest.mock as mock
-from collections import OrderedDict
 
 import metanorm.errors as errors
 import metanorm.normalizers as normalizers
@@ -74,10 +73,11 @@ class GeoSPaaSMetadataNormalizerTestCase(unittest.TestCase):
         """get_iso_topic_category() should return the "Oceans" keyword
         as default value
         """
-        self.assertDictEqual(
-            self.normalizer.get_iso_topic_category({}),
-            OrderedDict([('iso_topic_category', 'Oceans')])
-        )
+        with mock.patch('pythesint.get_iso19115_topic_category') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_iso_topic_category({}),
+                mock_get_gcmd_method.return_value)
+            mock_get_gcmd_method.assert_called_with('Oceans')
 
     def test_iso_topic_category_pti_error(self):
         """A MetadataNormalizationError must be raised in case of pythesint error"""
@@ -89,16 +89,11 @@ class GeoSPaaSMetadataNormalizerTestCase(unittest.TestCase):
         """get_gcmd_location() should return the "SEA SURFACE" keyword
         as default value
         """
-        self.assertDictEqual(
-            self.normalizer.get_gcmd_location({}),
-            OrderedDict([
-                ('Location_Category', 'VERTICAL LOCATION'),
-                ('Location_Type', 'SEA SURFACE'),
-                ('Location_Subregion1', ''),
-                ('Location_Subregion2', ''),
-                ('Location_Subregion3', '')
-            ])
-        )
+        with mock.patch('pythesint.get_gcmd_location') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_gcmd_location({}),
+                mock_get_gcmd_method.return_value)
+            mock_get_gcmd_method.assert_called_with('SEA SURFACE')
 
     def test_gcmd_location_pti_error(self):
         """A MetadataNormalizationError must be raised in case of pythesint error"""

--- a/tests/normalizers/test_gportal_gcom.py
+++ b/tests/normalizers/test_gportal_gcom.py
@@ -1,11 +1,10 @@
 """Tests for the GPortal GCOM-W normalizer"""
 import unittest
-from collections import OrderedDict
+import unittest.mock as mock
 from datetime import datetime
 from dateutil.tz import tzutc
 
 import metanorm.normalizers as normalizers
-from .data import DATASET_PARAMETERS
 from metanorm.errors import MetadataNormalizationError
 
 
@@ -97,25 +96,26 @@ class GPortalGCOMAMSR2L3MetadataNormalizerTestCase(unittest.TestCase):
         with self.assertRaises(MetadataNormalizationError):
             self.normalizer.get_time_coverage_end({})
 
-    def test_platform(self):
-        """platform from GPortalGCOMAMSR2L3MetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_platform({}),
-            OrderedDict([('Category', 'Earth Observation Satellites'),
-                         ('Series_Entity', ''),
-                         ('Short_Name', 'GCOM-W1'),
-                         ('Long_Name', 'Global Change Observation Mission 1st-Water')]))
+    def test_gcmd_platform(self):
+        """Test getting the platform"""
+        with mock.patch('metanorm.utils.get_gcmd_platform') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_platform({}),
+                mock_get_gcmd_method.return_value)
 
-    def test_instrument(self):
-        """instrument from GPortalGCOMAMSR2L3MetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_instrument({}),
-            OrderedDict([('Category', 'Earth Remote Sensing Instruments'),
-                         ('Class', 'Passive Remote Sensing'),
-                         ('Type', 'Spectrometers/Radiometers'),
-                         ('Subtype', 'Imaging Spectrometers/Radiometers'),
-                         ('Short_Name', 'AMSR2'),
-                         ('Long_Name', 'Advanced Microwave Scanning Radiometer 2')]))
+    def test_gcmd_instrument(self):
+        """Test getting the instrument"""
+        with mock.patch('metanorm.utils.get_gcmd_instrument') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_instrument({}),
+                mock_get_gcmd_method.return_value)
+
+    def test_gcmd_provider(self):
+        """Test getting the provider"""
+        with mock.patch('metanorm.utils.get_gcmd_provider') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_provider({}),
+                mock_get_gcmd_method.return_value)
 
     def test_location_geometry(self):
         """geometry from GPortalGCOMAMSR2L3MetadataNormalizer """
@@ -123,21 +123,9 @@ class GPortalGCOMAMSR2L3MetadataNormalizerTestCase(unittest.TestCase):
             self.normalizer.get_location_geometry({}),
             'POLYGON((-180 -90, -180 90, 180 90, 180 -90, -180 -90))')
 
-    def test_provider(self):
-        """provider from GPortalGCOMAMSR2L3MetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_provider({}),
-            OrderedDict([('Bucket_Level0', 'GOVERNMENT AGENCIES-NON-US'),
-                         ('Bucket_Level1', 'JAPAN'),
-                         ('Bucket_Level2', ''),
-                         ('Bucket_Level3', ''),
-                         ('Short_Name', 'JP/JAXA/EOC'),
-                         ('Long_Name', 'Earth Observation Center, Japan Aerospace Exploration '
-                                       'Agency, Japan'),
-                         ('Data_Center_URL', 'http://www.eorc.jaxa.jp/en/index.html')]))
-
     def test_dataset_parameters(self):
         """dataset_parameters from GPortalGCOMAMSR2L3MetadataNormalizer """
-        self.assertEqual(self.normalizer.get_dataset_parameters({}), [
-            DATASET_PARAMETERS['sea_surface_temperature']
-        ])
+        with mock.patch('metanorm.utils.create_parameter_list') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_dataset_parameters({}),
+                mock_get_gcmd_method.return_value)

--- a/tests/normalizers/test_nextsim.py
+++ b/tests/normalizers/test_nextsim.py
@@ -1,11 +1,10 @@
-"""Tests for the CPOM altimetry normalizer"""
+"""Tests for the nextsim normalizer"""
 
 import unittest
-from collections import OrderedDict
+import unittest.mock as mock
 from datetime import datetime, timezone
 
 import metanorm.normalizers as normalizers
-from .data import DATASET_PARAMETERS
 from metanorm.errors import MetadataNormalizationError
 
 
@@ -88,24 +87,26 @@ class NextsimMetadataNormalizerTests(unittest.TestCase):
         with self.assertRaises(MetadataNormalizationError):
             self.normalizer.get_time_coverage_end({})
 
-    def test_get_platform(self):
+    def test_gcmd_platform(self):
         """Test getting the platform"""
-        self.assertDictEqual(self.normalizer.get_platform({}),
-                             OrderedDict([('Category', 'Models/Analyses'),
-                                          ('Series_Entity', ''),
-                                          ('Short_Name', 'OPERATIONAL MODELS'),
-                                          ('Long_Name', '')]))
+        with mock.patch('metanorm.utils.get_gcmd_platform') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_platform({}),
+                mock_get_gcmd_method.return_value)
 
-    def test_get_instrument(self):
+    def test_gcmd_instrument(self):
         """Test getting the instrument"""
-        self.assertDictEqual(
-            self.normalizer.get_instrument({}),
-            OrderedDict([('Category', 'In Situ/Laboratory Instruments'),
-                         ('Class', 'Data Analysis'),
-                         ('Type', 'Environmental Modeling'),
-                         ('Subtype', ''),
-                         ('Short_Name', 'Computer'),
-                         ('Long_Name', 'Computer')]))
+        with mock.patch('metanorm.utils.get_gcmd_instrument') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_instrument({}),
+                mock_get_gcmd_method.return_value)
+
+    def test_gcmd_provider(self):
+        """Test getting the provider"""
+        with mock.patch('metanorm.utils.get_gcmd_provider') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_provider({}),
+                mock_get_gcmd_method.return_value)
 
     def test_get_location_geometry(self):
         """get_location_geometry() should return the location
@@ -114,46 +115,3 @@ class NextsimMetadataNormalizerTests(unittest.TestCase):
         self.assertEqual(
             self.normalizer.get_location_geometry({}),
             'POLYGON((-180 62,180 62,180 90,-180 90,-180 62))')
-
-    def test_get_provider(self):
-        """Test getting the provider"""
-        self.assertDictEqual(
-            self.normalizer.get_provider({}),
-            OrderedDict([
-                ('Bucket_Level0', 'CONSORTIA/INSTITUTIONS'),
-                ('Bucket_Level1', ''),
-                ('Bucket_Level2', ''),
-                ('Bucket_Level3', ''),
-                ('Short_Name', 'NERSC'),
-                ('Long_Name', 'Nansen Environmental and Remote Sensing Centre'),
-                ('Data_Center_URL', 'http://www.nersc.no/main/index2.php')]))
-
-    def test_get_parameters(self):
-        """Test getting the only dataset parameter"""
-        self.assertListEqual(
-            self.normalizer.get_dataset_parameters({
-                'raw_dataset_parameters': [
-                    'projection_y_coordinate',
-                    'projection_x_coordinate',
-                    'longitude',
-                    'latitude',
-                    'time',
-                    'sea_ice_area_fraction',
-                    'sea_ice_thickness',
-                    'surface_snow_thickness',
-                    'sea_ice_x_velocity',
-                    'sea_ice_y_velocity'
-                ],
-            }),
-            [
-                DATASET_PARAMETERS['projection_y_coordinate'],
-                DATASET_PARAMETERS['projection_x_coordinate'],
-                DATASET_PARAMETERS['longitude'],
-                DATASET_PARAMETERS['latitude'],
-                DATASET_PARAMETERS['time'],
-                DATASET_PARAMETERS['sea_ice_area_fraction'],
-                DATASET_PARAMETERS['sea_ice_thickness'],
-                DATASET_PARAMETERS['surface_snow_thickness'],
-                DATASET_PARAMETERS['sea_ice_x_velocity'],
-                DATASET_PARAMETERS['sea_ice_y_velocity']
-            ])

--- a/tests/normalizers/test_noaa_hycom.py
+++ b/tests/normalizers/test_noaa_hycom.py
@@ -1,11 +1,10 @@
 """Tests for the NOAA HYCOM normalizer"""
 import unittest
-from collections import OrderedDict
+import unittest.mock as mock
 from datetime import datetime
 from dateutil.tz import tzutc
 
 import metanorm.normalizers as normalizers
-from .data import DATASET_PARAMETERS
 from metanorm.errors import MetadataNormalizationError
 
 
@@ -145,25 +144,26 @@ class NOAAHYCOMMetadataNormalizerTestCase(unittest.TestCase):
         with self.assertRaises(MetadataNormalizationError):
             self.normalizer.get_time_coverage_end({})
 
-    def test_platform(self):
-        """platform from NOAAHYCOMMetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_platform({}),
-            OrderedDict([('Category', 'Models/Analyses'),
-                         ('Series_Entity', ''),
-                         ('Short_Name', 'OPERATIONAL MODELS'),
-                         ('Long_Name', '')]))
+    def test_gcmd_platform(self):
+        """Test getting the platform"""
+        with mock.patch('metanorm.utils.get_gcmd_platform') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_platform({}),
+                mock_get_gcmd_method.return_value)
 
-    def test_instrument(self):
-        """instrument from NOAAHYCOMMetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_instrument({}),
-            OrderedDict([('Category', 'In Situ/Laboratory Instruments'),
-                         ('Class', 'Data Analysis'),
-                         ('Type', 'Environmental Modeling'),
-                         ('Subtype', ''),
-                         ('Short_Name', 'Computer'),
-                         ('Long_Name', 'Computer')]))
+    def test_gcmd_instrument(self):
+        """Test getting the instrument"""
+        with mock.patch('metanorm.utils.get_gcmd_instrument') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_instrument({}),
+                mock_get_gcmd_method.return_value)
+
+    def test_gcmd_provider(self):
+        """Test getting the provider"""
+        with mock.patch('metanorm.utils.get_gcmd_provider') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_provider({}),
+                mock_get_gcmd_method.return_value)
 
     def test_geometry_hycom_region1(self):
         """Should return the proper geometry"""
@@ -225,29 +225,10 @@ class NOAAHYCOMMetadataNormalizerTestCase(unittest.TestCase):
         with self.assertRaises(MetadataNormalizationError):
             self.normalizer.get_location_geometry({'url': 'http://foo'})
 
-    def test_provider(self):
-        """provider from NOAAHYCOMMetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_provider({}),
-            OrderedDict([
-                ('Bucket_Level0', 'GOVERNMENT AGENCIES-U.S. FEDERAL AGENCIES'),
-                ('Bucket_Level1', 'DOC'),
-                ('Bucket_Level2', 'NOAA'),
-                ('Bucket_Level3', ''),
-                ('Short_Name', 'DOC/NOAA/NWS/NCEP'),
-                ('Long_Name',
-                 'National Centers for Environmental Prediction, National Weather Service, NOAA, '
-                 'U.S. Department of Commerce'),
-                ('Data_Center_URL', 'http://www.ncep.noaa.gov/')]))
 
     def test_dataset_parameters(self):
         """dataset_parameters from NOAAHYCOMMetadataNormalizer """
-        self.assertEqual(self.normalizer.get_dataset_parameters({}), [
-            DATASET_PARAMETERS['sea_water_salinity'],
-            DATASET_PARAMETERS['sea_water_temperature'],
-            DATASET_PARAMETERS['sea_water_salinity_at_bottom'],
-            DATASET_PARAMETERS['sea_water_temperature_at_bottom'],
-            DATASET_PARAMETERS['sea_surface_height_above_geoid'],
-            DATASET_PARAMETERS['eastward_sea_water_velocity'],
-            DATASET_PARAMETERS['northward_sea_water_velocity'],
-        ])
+        with mock.patch('metanorm.utils.create_parameter_list') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_dataset_parameters({}),
+                mock_get_gcmd_method.return_value)

--- a/tests/normalizers/test_noaa_rtofs.py
+++ b/tests/normalizers/test_noaa_rtofs.py
@@ -1,11 +1,10 @@
 """Tests for the NOAA RTOFS normalizer"""
 import unittest
-from collections import OrderedDict
+import unittest.mock as mock
 from datetime import datetime
 from dateutil.tz import tzutc
 
 import metanorm.normalizers as normalizers
-from .data import DATASET_PARAMETERS
 from metanorm.errors import MetadataNormalizationError
 
 
@@ -120,25 +119,26 @@ class NOAARTOFSMetadataNormalizerTestCase(unittest.TestCase):
         with self.assertRaises(MetadataNormalizationError):
             self.normalizer.get_time_coverage_end({})
 
-    def test_platform(self):
-        """platform from NOAARTOFSMetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_platform({}),
-            OrderedDict([('Category', 'Models/Analyses'),
-                         ('Series_Entity', ''),
-                         ('Short_Name', 'OPERATIONAL MODELS'),
-                         ('Long_Name', '')]))
+    def test_gcmd_platform(self):
+        """Test getting the platform"""
+        with mock.patch('metanorm.utils.get_gcmd_platform') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_platform({}),
+                mock_get_gcmd_method.return_value)
 
-    def test_instrument(self):
-        """instrument from NOAARTOFSMetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_instrument({}),
-            OrderedDict([('Category', 'In Situ/Laboratory Instruments'),
-                         ('Class', 'Data Analysis'),
-                         ('Type', 'Environmental Modeling'),
-                         ('Subtype', ''),
-                         ('Short_Name', 'Computer'),
-                         ('Long_Name', 'Computer')]))
+    def test_gcmd_instrument(self):
+        """Test getting the instrument"""
+        with mock.patch('metanorm.utils.get_gcmd_instrument') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_instrument({}),
+                mock_get_gcmd_method.return_value)
+
+    def test_gcmd_provider(self):
+        """Test getting the provider"""
+        with mock.patch('metanorm.utils.get_gcmd_provider') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_provider({}),
+                mock_get_gcmd_method.return_value)
 
     def test_location_geometry_global(self):
         """Should return the proper geometry"""
@@ -192,67 +192,68 @@ class NOAARTOFSMetadataNormalizerTestCase(unittest.TestCase):
         with self.assertRaises(MetadataNormalizationError):
             self.normalizer.get_location_geometry({})
 
-    def test_provider(self):
-        """provider from NOAARTOFSMetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_provider({}),
-            OrderedDict([
-                ('Bucket_Level0', 'GOVERNMENT AGENCIES-U.S. FEDERAL AGENCIES'),
-                ('Bucket_Level1', 'DOC'),
-                ('Bucket_Level2', 'NOAA'),
-                ('Bucket_Level3', ''),
-                ('Short_Name', 'DOC/NOAA/NWS/NCEP'),
-                ('Long_Name',
-                 'National Centers for Environmental Prediction, National Weather Service, NOAA, '
-                 'U.S. Department of Commerce'),
-                ('Data_Center_URL', 'http://www.ncep.noaa.gov/')]))
-
     def test_dataset_parameters_rtofs_2ds_diag(self):
         """Should return the proper dataset parameters"""
         attributes = {'url': 'ftp://ftpprd.ncep.noaa.gov/pub/data/nccf/com/rtofs/prod/'
                              'rtofs.20210518/rtofs_glo_2ds_f063_diag.nc'}
-        self.assertListEqual(self.normalizer.get_dataset_parameters(attributes), [
-            DATASET_PARAMETERS['sea_surface_height_above_geoid'],
-            DATASET_PARAMETERS['barotropic_eastward_sea_water_velocity'],
-            DATASET_PARAMETERS['barotropic_northward_sea_water_velocity'],
-            DATASET_PARAMETERS['surface_boundary_layer_thickness'],
-            DATASET_PARAMETERS['ocean_mixed_layer_thickness'],
-        ])
+        with mock.patch('metanorm.utils.create_parameter_list') as mock_utils_method:
+            self.assertEqual(
+                self.normalizer.get_dataset_parameters(attributes),
+                mock_utils_method.return_value)
+            mock_utils_method.assert_called_with([
+                'sea_surface_height_above_geoid',
+                'barotropic_eastward_sea_water_velocity',
+                'barotropic_northward_sea_water_velocity',
+                'surface_boundary_layer_thickness',
+                'ocean_mixed_layer_thickness',
+            ])
 
     def test_dataset_parameters_rtofs_2ds_prog(self):
         """Should return the proper dataset parameters"""
         attributes = {'url': 'ftp://ftpprd.ncep.noaa.gov/pub/data/nccf/com/rtofs/prod/'
                              'rtofs.20210518/rtofs_glo_2ds_f062_prog.nc'}
-        self.assertListEqual(self.normalizer.get_dataset_parameters(attributes), [
-            DATASET_PARAMETERS['eastward_sea_water_velocity'],
-            DATASET_PARAMETERS['northward_sea_water_velocity'],
-            DATASET_PARAMETERS['sea_surface_temperature'],
-            DATASET_PARAMETERS['sea_surface_salinity'],
-            DATASET_PARAMETERS['sea_water_potential_density'],
-        ])
+        with mock.patch('metanorm.utils.create_parameter_list') as mock_utils_method:
+            self.assertEqual(
+                self.normalizer.get_dataset_parameters(attributes),
+                mock_utils_method.return_value)
+            mock_utils_method.assert_called_with([
+                'eastward_sea_water_velocity',
+                'northward_sea_water_velocity',
+                'sea_surface_temperature',
+                'sea_surface_salinity',
+                'sea_water_potential_density',
+            ])
 
     def test_dataset_parameters_rtofs_2ds_ice(self):
         """Should return the proper dataset parameters"""
         attributes = {'url': 'ftp://ftpprd.ncep.noaa.gov/pub/data/nccf/com/rtofs/prod/'
                              'rtofs.20210518/rtofs_glo_2ds_f062_ice.nc'}
-        self.assertListEqual(self.normalizer.get_dataset_parameters(attributes), [
-            DATASET_PARAMETERS['ice_coverage'],
-            DATASET_PARAMETERS['ice_temperature'],
-            DATASET_PARAMETERS['ice_thickness'],
-            DATASET_PARAMETERS['ice_uvelocity'],
-            DATASET_PARAMETERS['icd_vvelocity'],
-        ])
+        with mock.patch('metanorm.utils.create_parameter_list') as mock_utils_method:
+            self.assertEqual(
+                self.normalizer.get_dataset_parameters(attributes),
+                mock_utils_method.return_value)
+            mock_utils_method.assert_called_with([
+                'ice_coverage',
+                'ice_temperature',
+                'ice_thickness',
+                'ice_uvelocity',
+                'icd_vvelocity',
+            ])
 
     def test_dataset_parameters_rtofs_3dz(self):
         """Should return the proper dataset parameters"""
         attributes = {'url': 'ftp://ftpprd.ncep.noaa.gov/pub/data/nccf/com/rtofs/prod/'
                              'rtofs.20210518/rtofs_glo_3dz_f024_daily_3zsio.nc'}
-        self.assertListEqual(self.normalizer.get_dataset_parameters(attributes), [
-            DATASET_PARAMETERS['eastward_sea_water_velocity'],
-            DATASET_PARAMETERS['northward_sea_water_velocity'],
-            DATASET_PARAMETERS['sea_surface_temperature'],
-            DATASET_PARAMETERS['sea_surface_salinity'],
-        ])
+        with mock.patch('metanorm.utils.create_parameter_list') as mock_utils_method:
+            self.assertEqual(
+                self.normalizer.get_dataset_parameters(attributes),
+                mock_utils_method.return_value)
+            mock_utils_method.assert_called_with([
+                'eastward_sea_water_velocity',
+                'northward_sea_water_velocity',
+                'sea_surface_temperature',
+                'sea_surface_salinity',
+            ])
 
     def test_dataset_parameters_missing_attribute(self):
         """An exception must be raised if the attribute is missing"""

--- a/tests/normalizers/test_podaac.py
+++ b/tests/normalizers/test_podaac.py
@@ -2,7 +2,6 @@
 
 import unittest
 import unittest.mock as mock
-from collections import OrderedDict
 from datetime import datetime, timezone
 
 import metanorm.normalizers as normalizers
@@ -119,11 +118,12 @@ class PODAACMetadataNormalizerTestCase(unittest.TestCase):
         with self.assertRaises(MetadataNormalizationError):
             self.normalizer.get_time_coverage_end({})
 
-    def test_get_platform(self):
+    def test_gcmd_platform(self):
         """Test getting the platform"""
-        with mock.patch('metanorm.utils.get_gcmd_platform') as mock_get_platform:
-            mock_get_platform.side_effect = lambda p: {'SENTINEL-1A': 'foo'}[p]
-            self.assertEqual(self.normalizer.get_platform({'platform': 'SENTINEL-1A'}), 'foo')
+        with mock.patch('metanorm.utils.get_gcmd_platform') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_platform({'platform': 'SENTINEL-1A'}),
+                mock_get_gcmd_method.return_value)
 
     def test_missing_platform(self):
         """A MetadataNormalizationError must be raised when the
@@ -132,11 +132,12 @@ class PODAACMetadataNormalizerTestCase(unittest.TestCase):
         with self.assertRaises(MetadataNormalizationError):
             self.normalizer.get_platform({})
 
-    def test_get_instrument(self):
+    def test_gcmd_instrument(self):
         """Test getting the instrument"""
-        with mock.patch('metanorm.utils.get_gcmd_instrument') as mock_get_instrument:
-            mock_get_instrument.side_effect = lambda p: {'VIIRS': 'foo'}[p]
-            self.assertEqual(self.normalizer.get_instrument({'sensor': 'VIIRS'}), 'foo')
+        with mock.patch('metanorm.utils.get_gcmd_instrument') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_instrument({'sensor': 'VIIRS'}),
+                mock_get_gcmd_method.return_value)
 
     def test_missing_sensor(self):
         """A MetadataNormalizationError must be raised when the
@@ -191,19 +192,20 @@ class PODAACMetadataNormalizerTestCase(unittest.TestCase):
             '-148.262 60.4, '
             '-147.443 25.982, '
             '-177.157 21.48, '
-            '-180 25.71789582937487, '
+            '-180 25.717895829374868, '
             '-180 55.60946639437804, '
             '-148.262 60.4)), '
-            '((180 25.71789582937487, '
+            '((180 25.717895829374868, '
             '161.791 52.861, '
             '180 55.60946639437804, '
-            '180 25.71789582937487)))')
+            '180 25.717895829374868)))')
 
     def test_get_location_geometry_from_geospatial_bounds_split_multipolygon(self):
         """Test getting the location geometry from the
         geospatial_bounds attribute with a multipolygon crossing the
         IDL
         """
+        self.maxDiff = None
         geometry = ('MULTIPOLYGON('
             '((-188.525390625 60.37042901631506,'
             '-165.14648437500003 56.46249048388978,'
@@ -227,32 +229,32 @@ class PODAACMetadataNormalizerTestCase(unittest.TestCase):
             }),
             'MULTIPOLYGON ('
             '((171.474609375 60.37042901631506, '
-            '180 58.94535368682163, '
+            '180 58.945353686821626, '
             '180 57.89199918002712, '
             '171.474609375 60.37042901631506)), '
-            '((-180 58.94535368682163, '
-            '-165.146484375 56.46249048388978, '
-            '-180 51.10473353644537, '
+            '((-180 58.945353686821626, '
+            '-165.14648437500003 56.46249048388978, '
+            '-180 51.104733536445366, '
             '-180 52.38008427459071, '
-            '-173.2324218750001 55.92458580482949, '
-            '-180 57.89199918002712, -180 58.94535368682163)), '
-            '((180 51.10473353644537, '
-            '172.177734375 48.2831928954835, '
+            '-173.23242187500006 55.92458580482949, '
+            '-180 57.89199918002712, -180 58.945353686821626)), '
+            '((180 51.104733536445366, '
+            '172.17773437499997 48.283192895483495, '
             '180 52.38008427459071, '
-            '180 51.10473353644537)), '
-            '((175.166015625 57.98480801923986, '
-            '180 56.80657678152991, '
+            '180 51.104733536445366)), '
+            '((175.166015625 57.984808019239864, '
+            '180 56.806576781529905, '
             '180 54.85557165879511, '
             '174.7265625 52.48278022207825, '
-            '175.166015625 57.98480801923986), '
-            '(178.154296875 56.63206372054478, '
-            '175.693359375 55.67758441108953, '
-            '178.505859375 54.80068486732236, '
-            '178.154296875 56.63206372054478)), '
-            '((-180 56.80657678152991, '
-            '-177.1875 56.12106042504411, '
+            '175.166015625 57.984808019239864), '
+            '(178.15429687500003 56.63206372054478, '
+            '175.693359375 55.677584411089526, '
+            '178.50585937500003 54.80068486732236, '
+            '178.15429687500003 56.63206372054478)), '
+            '((-180 56.806576781529905, '
+            '-177.18749999999997 56.12106042504411, '
             '-180 54.85557165879511, '
-            '-180 56.80657678152991)))')
+            '-180 56.806576781529905)))')
 
     def test_get_location_geometry_split_global_coverage(self):
         """Test getting the location geometry from a global bounding
@@ -327,19 +329,9 @@ class PODAACMetadataNormalizerTestCase(unittest.TestCase):
         with self.assertRaises(MetadataNormalizationError):
             self.normalizer.get_location_geometry({'northernmost_latitude': '9'})
 
-    def test_get_provider(self):
+    def test_gcmd_provider(self):
         """Test getting the provider"""
-        self.assertDictEqual(
-            self.normalizer.get_provider({}),
-            OrderedDict([
-                ('Bucket_Level0', 'GOVERNMENT AGENCIES-U.S. FEDERAL AGENCIES'),
-                ('Bucket_Level1', 'NASA'),
-                ('Bucket_Level2', ''),
-                ('Bucket_Level3', ''),
-                ('Short_Name', 'NASA/JPL/PODAAC'),
-                ('Long_Name',
-                 'Physical Oceanography Distributed Active Archive Center, Jet Propulsion '
-                 'Laboratory, NASA'),
-                ('Data_Center_URL', 'https://podaac.jpl.nasa.gov/')
-            ])
-        )
+        with mock.patch('metanorm.utils.get_gcmd_provider') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_provider({}),
+                mock_get_gcmd_method.return_value)

--- a/tests/normalizers/test_radarsat2_csv.py
+++ b/tests/normalizers/test_radarsat2_csv.py
@@ -1,7 +1,7 @@
 """Tests for the Radarsat 2 CSV normalizer"""
 import datetime as dt
 import unittest
-from collections import OrderedDict
+import unittest.mock as mock
 
 from dateutil.tz import tzutc
 
@@ -101,25 +101,26 @@ class Radarsat2CSVNormalizerTests(unittest.TestCase):
         with self.assertRaises(MetadataNormalizationError):
             self.normalizer.get_time_coverage_end({})
 
-    def test_get_platform(self):
-        """ shall return radarsat-2 """
-        self.assertEqual(
-            self.normalizer.get_platform(self.metadata),
-            OrderedDict([('Category', 'Earth Observation Satellites'),
-             ('Series_Entity', 'RADARSAT'),
-             ('Short_Name', 'RADARSAT-2'),
-             ('Long_Name', '')]))
+    def test_gcmd_platform(self):
+        """Test getting the platform"""
+        with mock.patch('metanorm.utils.get_gcmd_platform') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_platform({}),
+                mock_get_gcmd_method.return_value)
 
-    def test_get_instrument(self):
-        """ shall return c-sar """
-        self.assertEqual(
-            self.normalizer.get_instrument(self.metadata),
-            OrderedDict([('Category', 'Earth Remote Sensing Instruments'),
-                         ('Class', 'Active Remote Sensing'),
-                         ('Type', 'Imaging Radars'),
-                         ('Subtype', ''),
-                         ('Short_Name', 'C-SAR'),
-                         ('Long_Name', 'C-Band Synthetic Aperture Radar')]))
+    def test_gcmd_instrument(self):
+        """Test getting the instrument"""
+        with mock.patch('metanorm.utils.get_gcmd_instrument') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_instrument({}),
+                mock_get_gcmd_method.return_value)
+
+    def test_gcmd_provider(self):
+        """Test getting the provider"""
+        with mock.patch('metanorm.utils.get_gcmd_provider') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_provider({}),
+                mock_get_gcmd_method.return_value)
 
     def test_get_location_geometry(self):
         """ shall return POLYGON """
@@ -135,26 +136,9 @@ class Radarsat2CSVNormalizerTests(unittest.TestCase):
         with self.assertRaises(MetadataNormalizationError):
             self.normalizer.get_location_geometry({})
 
-    def test_get_provider(self):
-        """ shall return csa """
-        self.assertEqual(
-            self.normalizer.get_provider(self.metadata),
-            OrderedDict([('Bucket_Level0', 'COMMERCIAL'),
-                         ('Bucket_Level1', ''),
-                         ('Bucket_Level2', ''),
-                         ('Bucket_Level3', ''),
-                         ('Short_Name', 'CSA'),
-                         ('Long_Name', 'Cambridge Scientific Abstracts'),
-                         ('Data_Center_URL', 'http://www.csa.com/')]))
-
-    def test_get_parameters(self):
-        """ shall return sigma0 wkv """
-        self.assertCountEqual(
-            self.normalizer.get_dataset_parameters(self.metadata), [
-                OrderedDict([
-                    ('standard_name', 'surface_backwards_scattering_coefficient_of_radar_wave'),
-                    ('long_name', 'Normalized Radar Cross Section'),
-                    ('short_name', 'sigma0'),
-                    ('units', 'm/m'),
-                    ('minmax', '0 0.1'),
-                    ('colormap', 'gray')])])
+    def test_dataset_parameters(self):
+        """dataset_parameters from CEDAESACCIMetadataNormalizer """
+        with mock.patch('metanorm.utils.create_parameter_list') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_dataset_parameters({}),
+                mock_get_gcmd_method.return_value)

--- a/tests/normalizers/test_remss_gmi.py
+++ b/tests/normalizers/test_remss_gmi.py
@@ -1,11 +1,10 @@
 """Tests for the REMSS GMI normalizer"""
 import unittest
-from collections import OrderedDict
+import unittest.mock as mock
 from datetime import datetime
 from dateutil.tz import tzutc
 
 import metanorm.normalizers as normalizers
-from .data import DATASET_PARAMETERS
 from metanorm.errors import MetadataNormalizationError
 
 
@@ -116,25 +115,26 @@ class REMSSGMIMetadataNormalizerTestCase(unittest.TestCase):
         with self.assertRaises(MetadataNormalizationError):
             self.normalizer.get_time_coverage_end({})
 
-    def test_platform(self):
-        """platform from REMSSGMIMetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_platform({}),
-            OrderedDict([('Category', 'Earth Observation Satellites'),
-                         ('Series_Entity', ''),
-                         ('Short_Name', 'GPM'),
-                         ('Long_Name', 'Global Precipitation Measurement')]))
+    def test_gcmd_platform(self):
+        """Test getting the platform"""
+        with mock.patch('metanorm.utils.get_gcmd_platform') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_platform({}),
+                mock_get_gcmd_method.return_value)
 
-    def test_instrument(self):
-        """instrument from REMSSGMIMetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_instrument({}),
-            OrderedDict([('Category', 'Earth Remote Sensing Instruments'),
-                         ('Class', 'Passive Remote Sensing'),
-                         ('Type', 'Spectrometers/Radiometers'),
-                         ('Subtype', 'Imaging Spectrometers/Radiometers'),
-                         ('Short_Name', 'GMI'),
-                         ('Long_Name', 'Global Precipitation Measurement Microwave Imager')]))
+    def test_gcmd_instrument(self):
+        """Test getting the instrument"""
+        with mock.patch('metanorm.utils.get_gcmd_instrument') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_instrument({}),
+                mock_get_gcmd_method.return_value)
+
+    def test_gcmd_provider(self):
+        """Test getting the provider"""
+        with mock.patch('metanorm.utils.get_gcmd_provider') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_provider({}),
+                mock_get_gcmd_method.return_value)
 
     def test_location_geometry(self):
         """geometry from REMSSGMIMetadataNormalizer """
@@ -142,23 +142,9 @@ class REMSSGMIMetadataNormalizerTestCase(unittest.TestCase):
             self.normalizer.get_location_geometry({}),
             'POLYGON((-180 -90, -180 90, 180 90, 180 -90, -180 -90))')
 
-    def test_provider(self):
-        """provider from REMSSGMIMetadataNormalizer """
-        self.assertEqual(
-            self.normalizer.get_provider({}),
-            OrderedDict([('Bucket_Level0', 'COMMERCIAL'),
-                         ('Bucket_Level1', ''),
-                         ('Bucket_Level2', ''),
-                         ('Bucket_Level3', ''),
-                         ('Short_Name', 'RSS'),
-                         ('Long_Name', 'Remote Sensing Systems'),
-                         ('Data_Center_URL', 'http://www.remss.com/')]))
-
     def test_dataset_parameters(self):
-        """dataset_parameters from REMSSGMIMetadataNormalizer """
-        self.assertEqual(self.normalizer.get_dataset_parameters({}), [
-            DATASET_PARAMETERS['wind_speed'],
-            DATASET_PARAMETERS['atmosphere_mass_content_of_water_vapor'],
-            DATASET_PARAMETERS['atmosphere_mass_content_of_cloud_liquid_water'],
-            DATASET_PARAMETERS['rainfall_rate'],
-        ])
+        """dataset_parameters from CEDAESACCIMetadataNormalizer """
+        with mock.patch('metanorm.utils.create_parameter_list') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_dataset_parameters({}),
+                mock_get_gcmd_method.return_value)

--- a/tests/normalizers/test_scihub_odata.py
+++ b/tests/normalizers/test_scihub_odata.py
@@ -223,25 +223,16 @@ class ScihubODataMetadataNormalizerTestCase(unittest.TestCase):
     def test_dataset_parameters_sentinel1(self):
         """Test getting the dataset parameters for Sentinel 1 datasets
         """
-        self.assertListEqual(
-            self.normalizer.get_dataset_parameters({
-                'Identifier': 'S1B_IW_GRDH_1SDV_20210916T103902_20210916T103927_028722_036D80_C8D0'
-            }),
-            [
-                OrderedDict([
-                    ('standard_name', 'surface_backwards_scattering_coefficient_of_radar_wave'),
-                    ('canonical_units', '1'),
-                    ('definition', 'The scattering/absorption/attenuation coefficient is assumed to'
-                                   ' be an integral over all wavelengths, unless a coordinate of '
-                                   'radiation_wavelength is included to specify the wavelength. '
-                                   'Scattering of radiation is its deflection from its incident '
-                                   'path without loss of energy. Backwards scattering refers to the'
-                                   ' sum of scattering into all backward angles i.e. '
-                                   'scattering_angle exceeding pi/2 radians. A scattering_angle '
-                                   'should not be specified with this quantity.')
-                ])
-            ]
-        )
+        with mock.patch('metanorm.utils.create_parameter_list') as mock_get_gcmd_method:
+            self.assertEqual(
+                self.normalizer.get_dataset_parameters({
+                    'Identifier': 'S1B_IW_GRDH_1SDV_20210916T103902_20210916T103927_028722_036D80_'
+                                  'C8D0',
+                }),
+                mock_get_gcmd_method.return_value)
+            mock_get_gcmd_method.assert_called_with([
+                'surface_backwards_scattering_coefficient_of_radar_wave'
+            ])
 
     def test_unknown_dataset_parameters(self):
         """An empty list should be returned if no parameter is found"""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -309,9 +309,9 @@ class UtilsTestCase(unittest.TestCase):
             )])
         )
 
-    def test_restore_west_coordinates_west_idl(self):
+    def test_restore_west_coordinates_east_idl(self):
         """Test translating west coordinates back to [-180, 0[ for a
-        polygon on the west side of the IDL
+        polygon on the east side of the IDL
         """
         self.assertEqual(
             utils.restore_west_coordinates(
@@ -325,21 +325,20 @@ class UtilsTestCase(unittest.TestCase):
             )])
         )
 
-    def test_restore_west_coordinates_east_idl(self):
+    def test_restore_west_coordinates_west_idl(self):
         """Test translating west coordinates back to [-180, 0[ for a
-        polygon on the east side of the IDL. No modification should be
+        polygon on the west side of the IDL. No modification should be
         made
         """
         self.assertEqual(
             utils.restore_west_coordinates(
-                shapely.geometry.MultiPolygon([(
-                    [(10, 80), (10, 90), (20, 80), (10, 80)],
-                    []
-                )])),
-            shapely.geometry.MultiPolygon([(
-                [(10, 80), (10, 90), (20, 80), (10, 80)],
-                []
-            )])
+                shapely.geometry.MultiPolygon([
+                    ([(10, 80), (10, 90), (20, 80), (10, 80)], [])
+                ])),
+            shapely.geometry.MultiPolygon([
+                ([(10, 80), (10, 90), (20, 80), (10, 80)], [])
+            ])
+        )
         )
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -300,26 +300,45 @@ class UtilsTestCase(unittest.TestCase):
         self.assertEqual(
             utils.translate_west_coordinates(
                 shapely.geometry.MultiPolygon([(
-                    [(-10, 80), (-10, 90), (-50, 80), (-10, 80)],
+                    [(10, 80), (-10, 90), (-180, 80), (10, 80)],
                     [((-20, 83), (-20, 82), (-40, 81), (-20, 83))]
                 )])),
             shapely.geometry.MultiPolygon([(
-                [(350, 80), (350, 90), (310, 80), (350, 80)],
+                [(10, 80), (350, 90), (180, 80), (10, 80)],
                 [((340, 83), (340, 82), (320, 81), (340, 83))]
             )])
         )
 
-    def test_restore_west_coordinates(self):
-        """Test translating west corrdinates back to [-180, 0["""
+    def test_restore_west_coordinates_west_idl(self):
+        """Test translating west coordinates back to [-180, 0[ for a
+        polygon on the west side of the IDL
+        """
         self.assertEqual(
             utils.restore_west_coordinates(
                 shapely.geometry.MultiPolygon([(
-                    [(350, 80), (350, 90), (310, 80), (350, 80)],
+                    [(180, 80), (350, 80), (350, 90), (180, 80)],
                     [((340, 83), (340, 82), (320, 81), (340, 83))]
                 )])),
             shapely.geometry.MultiPolygon([(
-                [(-10, 80), (-10, 90), (-50, 80), (-10, 80)],
+                [(-180, 80), (-10, 80), (-10, 90), (-180, 80)],
                 [((-20, 83), (-20, 82), (-40, 81), (-20, 83))]
+            )])
+        )
+
+    def test_restore_west_coordinates_east_idl(self):
+        """Test translating west coordinates back to [-180, 0[ for a
+        polygon on the east side of the IDL. No modification should be
+        made
+        """
+        self.assertEqual(
+            utils.restore_west_coordinates(
+                shapely.geometry.MultiPolygon([(
+                    [(10, 80), (10, 90), (20, 80), (10, 80)],
+                    []
+                )])),
+            shapely.geometry.MultiPolygon([(
+                [(10, 80), (10, 90), (20, 80), (10, 80)],
+                []
             )])
         )
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -309,6 +309,20 @@ class UtilsTestCase(unittest.TestCase):
             )])
         )
 
+    def test_restore_west_coordinates(self):
+        """Test translating west corrdinates back to [-180, 0["""
+        self.assertEqual(
+            utils.restore_west_coordinates(
+                shapely.geometry.MultiPolygon([(
+                    [(350, 80), (350, 90), (310, 80), (350, 80)],
+                    [((340, 83), (340, 82), (320, 81), (340, 83))]
+                )])),
+            shapely.geometry.MultiPolygon([(
+                [(-10, 80), (-10, 90), (-50, 80), (-10, 80)],
+                [((-20, 83), (-20, 82), (-40, 81), (-20, 83))]
+            )])
+        )
+
 
 class SubclassesTestCase(unittest.TestCase):
     """Tests for utility functions dealing with subclasses"""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -362,6 +362,19 @@ class UtilsTestCase(unittest.TestCase):
             utils.split_multipolygon_along_idl(multipolygon),
             multipolygon)
 
+    def test_create_parameter_list(self):
+        """Test creating a parameter list from a list of names"""
+        def get_cf_or_wkv_standard_name_side_effect(name):
+            """Side effect function used for testing"""
+            return {'long_name': name}
+
+        with mock.patch('metanorm.utils.get_cf_or_wkv_standard_name',
+                        side_effect=get_cf_or_wkv_standard_name_side_effect):
+            self.assertListEqual(
+                utils.create_parameter_list(('foo', 'bar')),
+                [{'long_name': 'foo'}, {'long_name': 'bar'}]
+            )
+
 
 class SubclassesTestCase(unittest.TestCase):
     """Tests for utility functions dealing with subclasses"""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -115,6 +115,17 @@ class UtilsTestCase(unittest.TestCase):
         self.assertEqual(utils.translate_pythesint_keyword(translation_dict, 'alias22'), 'keyword2')
         self.assertEqual(utils.translate_pythesint_keyword(translation_dict, 'alias3'), 'alias3')
 
+    def test_get_gcmd_provider(self):
+        """Test looking for a GCMD provider"""
+        placeholder = {'foo': 'bar'}
+        with mock.patch('metanorm.utils.gcmd_search', side_effect=[None, placeholder]):
+            self.assertEqual(utils.get_gcmd_provider('baz'), placeholder)
+
+    def test_get_gcmd_provider_not_found(self):
+        """Test looking for a GCMD provider and not finding any"""
+        with mock.patch('metanorm.utils.gcmd_search', return_value=None):
+            self.assertIsNone(utils.get_gcmd_provider('baz'))
+
     def test_get_gcmd_platform(self):
         """Test getting a GCMD platform"""
         placeholder = {'foo': 'bar'}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -339,7 +339,28 @@ class UtilsTestCase(unittest.TestCase):
                 ([(10, 80), (10, 90), (20, 80), (10, 80)], [])
             ])
         )
+
+    def test_split_multipolygon_along_idl(self):
+        """Test splitting a multipolygon along the IDL"""
+        self.assertEqual(
+            utils.split_multipolygon_along_idl(
+                shapely.geometry.MultiPolygon([
+                    ([(-170, 80), (-170, 90), (170, 90), (170, 80), (-170, 80)], [])
+                ])),
+            shapely.geometry.MultiPolygon([
+                ([(-180, 90), (-170, 90), (-170, 80), (-180, 80), (-180, 90)], []),
+                ([(180, 80), (170, 80), (170, 90), (180, 90), (180, 80)], []),
+            ])
         )
+
+    def test_split_multipolygon_along_idl_global_coverage(self):
+        """When a dataset has global coverage, not splitting is needed"""
+        multipolygon = shapely.geometry.MultiPolygon([
+            ([(-180, 90), (-180, -90), (180, -90), (180, 90), (-180, 90)], [])
+        ])
+        self.assertEqual(
+            utils.split_multipolygon_along_idl(multipolygon),
+            multipolygon)
 
 
 class SubclassesTestCase(unittest.TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -222,6 +222,27 @@ class UtilsTestCase(unittest.TestCase):
             utils.restrict_gcmd_search(search_results, ['qux', 'grault']),
             [{'foo': 'bar', 'baz': 'qux', 'corge': 'grault'}])
 
+    def test_get_cf_standard_name(self):
+        """Test getting a standardized dataset parameter from the CF
+        vocabulary
+        """
+        placeholder = {'foo': 'bar'}
+        with mock.patch('pythesint.get_cf_standard_name', return_value=placeholder):
+            self.assertEqual(
+                utils.get_cf_or_wkv_standard_name('baz'),
+                placeholder)
+
+    def test_get_wkv_standard_name(self):
+        """Test getting a standardized dataset parameter from the well
+        known vocabularies
+        """
+        placeholder = {'foo': 'bar'}
+        with mock.patch('pythesint.get_cf_standard_name', side_effect=IndexError), \
+                mock.patch('pythesint.get_wkv_variable', return_value=placeholder):
+            self.assertEqual(
+                utils.get_cf_or_wkv_standard_name('baz'),
+                placeholder)
+
     def test_raises_decorator(self):
         """Test that the `raises()` decorator raises a
         MetadataNormalizationError when the function it decorates

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -133,6 +133,26 @@ class UtilsTestCase(unittest.TestCase):
                     ('Long_Name', 'foo')
                 ]))
 
+    def test_get_gcmd_instrument(self):
+        """Test getting a GCMD instrument"""
+        placeholder = {'foo': 'bar'}
+        with mock.patch('metanorm.utils.gcmd_search', return_value=placeholder):
+            self.assertEqual(utils.get_gcmd_instrument('baz'), placeholder)
+
+    def test_get_gcmd_instrument_unknown(self):
+        """Test getting an unknown GCMD instrument"""
+        with mock.patch('metanorm.utils.gcmd_search', return_value=None):
+            self.assertEqual(
+                utils.get_gcmd_instrument('foo'),
+                OrderedDict([
+                    ('Category', utils.UNKNOWN),
+                    ('Class', utils.UNKNOWN),
+                    ('Type', utils.UNKNOWN),
+                    ('Subtype', utils.UNKNOWN),
+                    ('Short_Name', 'foo'),
+                    ('Long_Name', 'foo')
+                ]))
+
     def test_raises_decorator(self):
         """Test that the `raises()` decorator raises a
         MetadataNormalizationError when the function it decorates

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -286,6 +286,12 @@ class UtilsTestCase(unittest.TestCase):
         with self.assertRaises(ValueError):
             get_foo(mock.Mock(), {})
 
+    def test_wkt_polygon_from_wgs84_limits(self):
+        """Test making a WKT polygon string from box bounds"""
+        self.assertEqual(
+            utils.wkt_polygon_from_wgs84_limits(90, 60, 180, -180),
+            'POLYGON((-180 60,180 60,180 90,-180 90,-180 60))')
+
 
 class SubclassesTestCase(unittest.TestCase):
     """Tests for utility functions dealing with subclasses"""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -164,6 +164,51 @@ class UtilsTestCase(unittest.TestCase):
                     ('Long_Name', 'foo')
                 ]))
 
+    def test_gcmd_search_one_result(self):
+        """Test searching GCMD vocabularies when only one result is
+        found by Pythesint
+        """
+        with mock.patch("pythesint.json_vocabulary.JSONVocabulary.get_list",
+                        return_value=[{'foo': 'bar', 'baz': 'qux'}]):
+            self.assertEqual(
+                utils.gcmd_search('instrument', 'bar', ['quux']),
+                {'foo': 'bar', 'baz': 'qux'})
+
+    def test_gcmd_search_unambiguous_selection(self):
+        """Test searching GCMD vocabularies when multiple results are
+        found by pythesint and an additional keyword allows to select
+        one without ambiguity
+        """
+        search_results = [
+            {'foo': 'bar', 'baz': 'qux'},
+            {'foo': 'bar', 'baz': 'quux'},
+        ]
+        with mock.patch("pythesint.json_vocabulary.JSONVocabulary.get_list",
+                        return_value=search_results):
+            self.assertEqual(
+                utils.gcmd_search('instrument', 'bar', ['quux']),
+                {'foo': 'bar', 'baz': 'quux'})
+
+    def test_gcmd_search_arbitrary_selection(self):
+        """Test searching GCMD vocabularies when multiple results are
+        found by pythesint and the additional keyword does not allow to
+        select one. The first result is then selected.
+        """
+        search_results = [
+            {'foo': 'bar', 'baz': 'qux'},
+            {'foo': 'bar', 'baz': 'qux', 'corge': 'grault'},
+        ]
+        with mock.patch("pythesint.json_vocabulary.JSONVocabulary.get_list",
+                        return_value=search_results):
+            self.assertEqual(
+                utils.gcmd_search('instrument', 'bar', ['qux']),
+                {'foo': 'bar', 'baz': 'qux'})
+
+    def test_gcmd_search_no_result(self):
+        """Test searching GCMD vocabularies when no result is found"""
+        with mock.patch("pythesint.json_vocabulary.JSONVocabulary.get_list", return_value=[]):
+            self.assertIsNone(utils.gcmd_search('instrument', 'bar', ['qux']))
+
     def test_raises_decorator(self):
         """Test that the `raises()` decorator raises a
         MetadataNormalizationError when the function it decorates

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -115,14 +115,23 @@ class UtilsTestCase(unittest.TestCase):
         self.assertEqual(utils.translate_pythesint_keyword(translation_dict, 'alias22'), 'keyword2')
         self.assertEqual(utils.translate_pythesint_keyword(translation_dict, 'alias3'), 'alias3')
 
-    def test_get_gcmd_metopb_platform(self):
-        """Test getting the right METOP-B platform"""
-        self.assertEqual(
-            utils.get_gcmd_platform('METOP_B'),
-            OrderedDict([('Category', 'Earth Observation Satellites'),
-                         ('Series_Entity', 'METOP'),
-                         ('Short_Name', 'METOP-B'),
-                         ('Long_Name', 'Meteorological Operational Satellite - B')]))
+    def test_get_gcmd_platform(self):
+        """Test getting a GCMD platform"""
+        placeholder = {'foo': 'bar'}
+        with mock.patch('metanorm.utils.gcmd_search', return_value=placeholder):
+            self.assertEqual(utils.get_gcmd_platform('baz'), placeholder)
+
+    def test_get_gcmd_platform_unknown(self):
+        """Test getting an unknown GCMD platform"""
+        with mock.patch('metanorm.utils.gcmd_search', return_value=None):
+            self.assertEqual(
+                utils.get_gcmd_platform('foo'),
+                OrderedDict([
+                    ('Category', utils.UNKNOWN),
+                    ('Series_Entity', utils.UNKNOWN),
+                    ('Short_Name', 'foo'),
+                    ('Long_Name', 'foo')
+                ]))
 
     def test_raises_decorator(self):
         """Test that the `raises()` decorator raises a

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,6 +7,7 @@ from datetime import datetime
 
 from dateutil.relativedelta import relativedelta
 from dateutil.tz import tzutc
+import shapely.geometry
 
 import metanorm.errors as errors
 import metanorm.utils as utils
@@ -291,6 +292,22 @@ class UtilsTestCase(unittest.TestCase):
         self.assertEqual(
             utils.wkt_polygon_from_wgs84_limits(90, 60, 180, -180),
             'POLYGON((-180 60,180 60,180 90,-180 90,-180 60))')
+
+    def test_translate_west_coordinates(self):
+        """Test translating west coordinates from [-180, 0[ to
+        [180, 360[
+        """
+        self.assertEqual(
+            utils.translate_west_coordinates(
+                shapely.geometry.MultiPolygon([(
+                    [(-10, 80), (-10, 90), (-50, 80), (-10, 80)],
+                    [((-20, 83), (-20, 82), (-40, 81), (-20, 83))]
+                )])),
+            shapely.geometry.MultiPolygon([(
+                [(350, 80), (350, 90), (310, 80), (350, 80)],
+                [((340, 83), (340, 82), (320, 81), (340, 83))]
+            )])
+        )
 
 
 class SubclassesTestCase(unittest.TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -209,6 +209,19 @@ class UtilsTestCase(unittest.TestCase):
         with mock.patch("pythesint.json_vocabulary.JSONVocabulary.get_list", return_value=[]):
             self.assertIsNone(utils.gcmd_search('instrument', 'bar', ['qux']))
 
+    def test_restrict_gcmd_search(self):
+        """Test restricting the results of a GCMD search using
+        additional keywords. The keyword which restricts the search
+        the most should be used
+        """
+        search_results = [
+            {'foo': 'bar', 'baz': 'qux'},
+            {'foo': 'bar', 'baz': 'qux', 'corge': 'grault'},
+        ]
+        self.assertEqual(
+            utils.restrict_gcmd_search(search_results, ['qux', 'grault']),
+            [{'foo': 'bar', 'baz': 'qux', 'corge': 'grault'}])
+
     def test_raises_decorator(self):
         """Test that the `raises()` decorator raises a
         MetadataNormalizationError when the function it decorates


### PR DESCRIPTION
Resolves #126 

Stop testing for actual values in the output of Pythesint; use mocks instead.